### PR TITLE
feat: Allow newlines within `ParameterList` and `ImportStatement`

### DIFF
--- a/src/language/grammar/otl.grammar
+++ b/src/language/grammar/otl.grammar
@@ -105,8 +105,8 @@ List {
 }
 
 // Imports
-ImportStatement { 
-  kw<"import"> "{" ImportedSymbols "}" kw<"from"> String 
+ImportStatement {
+  kw<"import"> "{" ImportedSymbols "}" kw<"from"> String
 }
 
 // or Specifiers?
@@ -196,7 +196,7 @@ String {
 @precedence {
   TypeDeclaration
   ImportStatement
-  Float 
+  Float
   Integer
   Assignment
   AssignmentName

--- a/src/language/grammar/otl.grammar
+++ b/src/language/grammar/otl.grammar
@@ -55,11 +55,11 @@ AssignmentValue {
 }
 
 AssignmentType {
-  Identifier ~statement ("[" ParameterList "]")?
+  Identifier ~statement ("[" newline* ParameterList newline* "]")?
 }
 
 ParameterList {
-  Parameter ("," Parameter)*
+  Parameter ("," newline* Parameter)*
 }
 
 Parameter {
@@ -106,12 +106,12 @@ List {
 
 // Imports
 ImportStatement {
-  kw<"import"> "{" ImportedSymbols "}" kw<"from"> String
+  kw<"import"> "{" newline* ImportedSymbols newline* "}" kw<"from"> String
 }
 
 // or Specifiers?
 ImportedSymbols {
-  ImportedSymbol ("," ImportedSymbol)*
+  ImportedSymbol ("," newline* ImportedSymbol)*
 }
 
 ImportedSymbol {


### PR DESCRIPTION
Allow newlines in certain places to allow spliting very large field types and import lists across multiple lines while making sure the grammar remains unambiguous.

Newlines are now allowed in the following places:

1) Directly after the opening bracket `[` of a parameter list resp. directly after the opening brace `{` of an imported name list.
2) Directly after (but not before) a comma `,` within a parameter list or imported name list.
3) Directly before the closing bracket `]` of a parameter list resp. directly before the closing brace `}` of an imported name list.
4) As before: To terminate a syntactically valid declaration or line comment
5) As before: Before, after and between the declarations within a section
6) As before: Within triple-quoted strings

So these are valid:

> [!TIP]
> :white_check_mark: **Valid Examples:**
>
> ```
> Note[
>     "TypeA",
>     "TypeB"
> ]
> ```
> 
> ```
> Note
> ```
> 
> ```
> Note["TypeA"]
> ```
> 
> ```
> Note["TypeA"
> ]
> ```
> 
> ```
> Note[
>     "TypeA"]
> ```

While all of these are not:

> [!CAUTION]
> :x: **Invalid Examples:**
> ```
> Note
> ["TypeA"]
> ```
> 
> ```
> Note[
>     "TypeA"
>     , "TypeB"
> ]
> ```