### PR TITLE
fix: Fix `react-lite-youtube-embed`  to `2.3.52` to avoid version incompatibility

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "react-lite-youtube-embed": "^2.3.52"
+    "react-lite-youtube-embed": "2.3.52"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.0"


### PR DESCRIPTION
The `react-lite-youtube-embed` package does not strictly follow semantic versioning because minor releases might require new major releases of `react`.