### PR TITLE
types: Fix typing of `src/api.ts`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -44,15 +44,15 @@ export class TypingAPI {
     note(path: string): Note {
         return Note.new(path);
     }
-    type(opt: string | { path?: string; folder?: string; name?: string }): Type {
-        if (typeof opt == "string") {
+    type(opt: string | { path?: string; folder?: string; name?: string }): Type | null {
+        if (typeof opt === "string") {
             return gctx.graph.get({ name: opt });
         }
         let { name, folder, path } = opt;
         return gctx.graph.get({ name, folder, path });
     }
 
-    lib: PromiseType<ReturnType<typeof importModules>>;
+    lib!: PromiseType<ReturnType<typeof importModules>>;
 
     import(path: string): Record<string, any> {
         let mod = gctx.importManager.importSmart(path);
@@ -67,7 +67,7 @@ export class TypingAPI {
 
     _import_explicit(path: string, symbols: any[], base?: string): Record<string, any> {
         if (path in this.lib) {
-            return this.lib[path as keyof typeof this.lib];
+            return this.lib[path as keyof typeof this.lib]!;
         }
         let mod = gctx.importManager.importSmart(path, base);
         if (mod == null) {


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.

All usages of the definite assignment operator (i.e. <code><em>&lt;expr&gt;</em>!</code>) have been verified to be safe.