### PR TITLE
types: Fix typing of `src/language/**`

### DIFF
--- a/src/language/visitors/composite/list.ts
+++ b/src/language/visitors/composite/list.ts
@@ -1,4 +1,5 @@
 import { snippet, startCompletion } from "@codemirror/autocomplete";
+import { SyntaxNode } from "@lezer/common";
 import * as Visitors from ".";
 import { createVisitor, Rules, TVisitorBase } from "../index_base";
 
@@ -13,7 +14,7 @@ export const List = (valueType: TVisitorBase, opts?: { info?: string }) =>
         },
         run() {
             let result: ReturnType<(typeof valueType)["run"]>[] = [];
-            let unexpectedNodes = [];
+            let unexpectedNodes: SyntaxNode[] = [];
             this.traverse(
                 (node, child) => {
                     result.push(child.run(node));

--- a/src/language/visitors/toplevel/expression.ts
+++ b/src/language/visitors/toplevel/expression.ts
@@ -17,7 +17,7 @@ export const Expression = createVisitor({
                 let children = this.runChildren();
                 for (let key in children) {
                     // return first key
-                    return children[key];
+                    return children[key as keyof typeof children];
                 }
             },
         }),

--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -241,7 +241,7 @@ export const Type = createVisitor({
                 ).extend({
                     run(node) {
                         let methodsList = this.runChildren()["body"];
-                        let methods = {};
+                        let methods: Record<string, Method> = {};
                         for (let { name, value } of methodsList) {
                             methods[name] = Method.new({ function: value });
                         }

--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -36,7 +36,7 @@ export const TypeParentsClause = createVisitor({
         this.traverse((node, child) => {
             let name = child.run(node);
             for (let type of globalTypes) {
-                if (type.name == name && type.node.to <= node.from) {
+                if (type.name === name && type.node.to <= node.from) {
                     return;
                 }
             }

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -300,7 +300,7 @@ export class Visitor<
             Merge<Utils, Utils2>,
             Merge<CacheType, CacheType2>,
             NewSuper
-            // @ts-expect-error TODO: fix
+        // @ts-expect-error TODO: fix
         >(newArgs);
         result.super = Visitor.fromArgs<Return, Children, Utils, CacheType, Super>(this.originalArgs) as NewSuper;
         result.super.derived = result;
@@ -329,7 +329,7 @@ export class Visitor<
                 if (this.args.utils[key] != null) {
                     try {
                         this.args.utils[key] = this.args.utils[key].bind(this);
-                    } catch {}
+                    } catch { }
                 }
             }
         }
@@ -919,14 +919,15 @@ export class Visitor<
             if (tags && visitor.tags) {
                 for (let tag of tags) {
                     if (visitor.tags.contains(tag)) {
-                        return visitor;
+                        return visitor as VisitorWithRule<R>;
                     }
                 }
             }
             if (rules && visitor.rules) {
+                let visitorRules = visitor.rules instanceof Array ? visitor.rules : [visitor.rules];
                 for (let rule of rules) {
-                    if (visitor.rules.contains(rule)) {
-                        return visitor;
+                    if (visitorRules.contains(rule as Rules)) {
+                        return visitor as VisitorWithRule<R>;
                     }
                 }
             }

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -40,17 +40,19 @@ export interface Symbol {
     metadata?: any;
 }
 
-let cache: NodeWeakMap<WeakMap<Visitor<any, any, any, any, any>, CacheEntry>>;
+type AnyVisitor = Visitor<any, any, any, any, any>;
+
+let cache: NodeWeakMap<WeakMap<AnyVisitor, CacheEntry>>;
 
 function resetCache() {
-    cache = new NodeWeakMap<WeakMap<Visitor<any, any, any, any, any>, CacheEntry>>();
+    cache = new NodeWeakMap<WeakMap<AnyVisitor, CacheEntry>>();
 }
 
 type CallType = "lint" | "run" | "complete" | "accept" | "symbols" | "snippets" | "decorations" | "hover";
 
 interface StackFrame {
     node: SyntaxNode;
-    visitor: Visitor<any, any, any, any, any>;
+    visitor: AnyVisitor;
     context: LocalContext;
     call: CallType;
 }

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -18,7 +18,7 @@ interface CompletionEntry extends Completion {
 }
 
 interface CacheEntry {
-    callCache: {
+    callCache: Partial<{
         accept: boolean;
         run: any;
         lint: { diagnostics: Diagnostic[]; hasErrors: boolean };
@@ -26,7 +26,7 @@ interface CacheEntry {
         snippets: CompletionEntry[];
         symbols: Symbol[];
         decorations: Range<Decoration>[];
-    };
+    }>;
     diagnostics: Diagnostic[];
 }
 

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -628,7 +628,7 @@ export class Visitor<
         // options = mergeDeep({ keys: [], eager: false, traversalOptions: {} }, options);
 
         let result = {} as Partial<{ [K in Key]: VisitorReturn<K> }>;
-        let traversalOptions = options.traversalOptions ?? {};
+        let traversalOptions = { ...options.traversalOptions };
         traversalOptions.selectChildren = options?.keys;
 
         let fulfilledKeys: Set<Key>;


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.