### PR TITLE
types: Fix typing of `src/utils/*`

### DIFF
--- a/src/utilities/css_manager.ts
+++ b/src/utilities/css_manager.ts
@@ -1,10 +1,10 @@
 import createEmotion, { Emotion } from "@emotion/css/create-instance";
 import { gctx } from "src/context";
-import { getFont } from "./font_manager";
+import { FontName, getFont } from "./font_manager";
 
 export class CSSManager {
     emotion: Emotion;
-    enabledFonts: Set<string>;
+    enabledFonts: Set<FontName>;
 
     constructor(key: string) {
         this.emotion = createEmotion({
@@ -23,7 +23,7 @@ export class CSSManager {
         this.enabledFonts = new Set();
     }
 
-    async enableFont(name: string) {
+    async enableFont(name: FontName) {
         let css = await getFont(name);
         if (!css) return;
 

--- a/src/utilities/font_manager.ts
+++ b/src/utilities/font_manager.ts
@@ -13,6 +13,8 @@ interface FontSpec {
     fontFiles: { [relativePath: string]: string };
 }
 
+export type FontName = FONTS | string;
+
 type FONTS = "fontawesome" | "lucide";
 const FONT_SPECS: Record<FONTS, FontSpec> = {
     fontawesome: {
@@ -58,11 +60,11 @@ function getFontCacheDir() {
     return `${gctx.plugin.manifest.dir}/font-cache/`;
 }
 
-function getFontCachePath(name: FONTS) {
+function getFontCachePath(name: FontName) {
     return `${getFontCacheDir()}/${name}.css`;
 }
 
-export async function getFont(name: FONTS) {
+export async function getFont(name: FontName) {
     const cacheDir = getFontCacheDir();
     const cachePath = getFontCachePath(name);
     const adapter = gctx.app.vault.adapter;
@@ -70,7 +72,7 @@ export async function getFont(name: FONTS) {
         return await adapter.read(cachePath);
     }
 
-    const spec = FONT_SPECS[name];
+    const spec = FONT_SPECS[name as FONTS];
     if (!spec) return null;
 
     const css = await downloadFont(spec);

--- a/src/utilities/link_rendering.tsx
+++ b/src/utilities/link_rendering.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import classNames from "classnames";
 import { AlertTriangle } from "lucide-react";
+import { ComponentChildren } from "preact";
 import { useState } from "react";
 import styles from "src/styles/link.scss";
 import { Note, Type } from "src/typing";
@@ -22,16 +23,16 @@ const ErrContainer = styled.span`
     border-color: 1px solid var(--background-modifier-border);
 `;
 
-const Error = ({ children }) => {
+const Error = ({ children }: { children: ComponentChildren }) => {
     let [open, setOpen] = useState(false);
     return (
         <ErrContainer
-            onMouseEnter={(e) => {
+            onMouseEnter={(e: MouseEvent) => {
                 e.stopPropagation();
                 e.preventDefault();
                 setOpen(true);
             }}
-            onMouseLeave={(e) => {
+            onMouseLeave={(e: MouseEvent) => {
                 e.stopPropagation();
                 e.preventDefault();
                 setOpen(false);


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.