### PR TITLE
types: Fix typing of `src/test/*` and `__mocks__/*`

### DIFF
--- a/__mocks__/__vault__/scripts/hooks-sink.tsx
+++ b/__mocks__/__vault__/scripts/hooks-sink.tsx
@@ -1,5 +1,7 @@
-export const hookCalls: { hookName: string, ctx: any }[] = [];
+// @ts-ignore // Transpilation of TS files is not yet supported
+export const hookCalls /*: { hookName: string, ctx: any }[]*/ = [];
 
-export function appendHookCall(hookName: string, ctx: any) {
+// @ts-ignore // Transpilation of TS files is not yet supported
+export function appendHookCall(hookName /*: string*/, ctx /*: any*/) {
     hookCalls.push({ hookName, ctx });
 }

--- a/__mocks__/__vault__/scripts/hooks-sink.tsx
+++ b/__mocks__/__vault__/scripts/hooks-sink.tsx
@@ -1,5 +1,5 @@
-export const hookCalls = [];
+export const hookCalls: { hookName: string, ctx: any }[] = [];
 
-export function appendHookCall(hookName, ctx) {
+export function appendHookCall(hookName: string, ctx: any) {
     hookCalls.push({ hookName, ctx });
 }

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -41,7 +41,7 @@ export class Workspace {
 }
 
 export class MetadataCache extends Events {
-    getFileCache(tfile: TFile) {
+    getFileCache(tfile: TFile): null {
         return null;
     }
 }
@@ -57,6 +57,7 @@ export class App {
     vault: Vault;
     workspace: Workspace;
     metadataCache: MetadataCache;
+    fileManager: FileManager;
     constructor(vault: Vault) {
         this.vault = vault;
         this.workspace = new Workspace();
@@ -101,7 +102,7 @@ export class TFile extends TAbstractFile {
         this.basename = Path.basename(this.path, Path.extname(this.path));
         this.extension = Path.extname(this.path);
         this.content = content;
-        this.stat = { size: content.byteLength || content.length };
+        this.stat = { size: (content as ArrayBuffer).byteLength || (content as string).length };
     }
 }
 

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -84,19 +84,20 @@ export class Plugin {
 export abstract class TextFileView {}
 
 export abstract class TAbstractFile {
-    vault: Vault;
-    path: string;
-    name: string;
-    parent: TFolder;
+    abstract vault: Vault;
+    abstract path: string;
+    abstract name: string;
+    abstract parent: TFolder | null;
 }
 
 export class TFile extends TAbstractFile {
     stat: any;
+    name: string;
     basename: string;
     extension: string;
     content: string | ArrayBuffer;
 
-    constructor(public vault: Vault, public path: string, public parent: TFolder, content: string | ArrayBuffer) {
+    constructor(public vault: Vault, public path: string, public parent: TFolder | null, content: string | ArrayBuffer) {
         super();
         this.name = Path.basename(this.path);
         this.basename = Path.basename(this.path, Path.extname(this.path));
@@ -107,6 +108,8 @@ export class TFile extends TAbstractFile {
 }
 
 export class TFolder extends TAbstractFile {
+    name: string;
+
     isRoot(): boolean {
         return this.path === "/";
     }
@@ -114,7 +117,7 @@ export class TFolder extends TAbstractFile {
     constructor(
         public vault: Vault,
         public path: string,
-        public parent: TFolder,
+        public parent: TFolder | null,
         public children: TAbstractFile[] = []
     ) {
         super();
@@ -126,7 +129,7 @@ export class Vault extends Events {
     files: Map<string, TAbstractFile>;
     root: TFolder;
     name: string = "mock-vault";
-    vaultPath: string;
+    vaultPath?: string;
 
     constructor(vaultPath?: string) {
         super();
@@ -139,6 +142,9 @@ export class Vault extends Events {
     }
 
     private loadFilesFromFS(folderPath: string, parent: TFolder | null) {
+        if (this.vaultPath === undefined) {
+            throw new Error("No vaultPath has been configured")
+        }
         const directoryEntries = fs.readdirSync(Path.join(this.vaultPath, folderPath));
         for (const entryName of directoryEntries) {
             const entryPath = Path.join(folderPath, entryName);

--- a/src/test/field_accessor.test.ts
+++ b/src/test/field_accessor.test.ts
@@ -14,7 +14,10 @@ async function testAccessor(
 }
 
 function defineType(fields: string[]) {
-    const result = {
+    const result: {
+        name: string,
+        fields: Record<string, Field>,
+    } = {
         name: "Test",
         fields: {},
     };

--- a/src/test/otl-interpreter.test.ts
+++ b/src/test/otl-interpreter.test.ts
@@ -263,7 +263,7 @@ type A {
 }
 `);
             expect(A.style[marginal]).toBeInstanceOf(FnScript);
-            assume(A.style[marginal], FnScript);
+            assume(A.style[marginal], FnScript<IScriptContextBase>);
             expect(A.style[marginal].call({})).toBeDefined();
         });
 
@@ -278,7 +278,7 @@ type A {
 }
 `);
             expect(A.style[marginal]).toBeInstanceOf(ExprScript);
-            assume(A.style[marginal], ExprScript);
+            assume(A.style[marginal], ExprScript<IScriptContextBase>);
             expect(A.style[marginal].call({})).toBeDefined();
         });
 
@@ -310,6 +310,7 @@ type A {
 }
 `);
         expect(A.style.link).toBeInstanceOf(FnScript);
+        assume(A.style.link, FnScript<ILinkScriptContext>)
         expect(A.style.link.call({})).toBeDefined();
     });
 
@@ -324,7 +325,7 @@ type A {
 }
 `);
         expect(A.style.link).toBeInstanceOf(ExprScript);
-        assume(A.style.link, ExprScript);
+        assume(A.style.link, ExprScript<ILinkScriptContext>);
         expect(A.style.link.call({})).toBeDefined();
     });
 });

--- a/src/test/otl-interpreter.test.ts
+++ b/src/test/otl-interpreter.test.ts
@@ -1,14 +1,21 @@
 import { App, Vault } from "obsidian";
 import { gctx } from "src/context";
 import TypingPlugin from "src/main";
-import { ExprScript } from "src/scripting";
-import { FieldTypes, Type } from "src/typing";
+import { ExprScript, FnScript, IScriptContextBase } from "src/scripting";
+import { FieldTypes, Method, Type, Values } from "src/typing";
+import { ILinkScriptContext } from "src/typing/style";
+
+// `assume` is used to tell the TypeScript compiler about facts already verified via jest.
+function assume<E extends abstract new (...args: any) => any = any>(value: any, expected?: E): asserts value is InstanceType<E> {
+}
 
 beforeAll(async () => {
     gctx.testing = true;
+    // @ts-ignore
     let app = new App(new Vault());
     let plugin = new TypingPlugin(app, null);
     await plugin.onload();
+    // @ts-ignore
     await app.workspace.triggerLayoutReady();
 });
 
@@ -20,7 +27,7 @@ function evaluateOTL(source: string): Record<string, Type> {
     return module.env;
 }
 
-function evaluateOTLErrors(source: string): Record<string, Type> {
+function evaluateOTLErrors(source: string): string {
     let module = gctx.interpreter.importModule("test.otl", source);
     expect(module).toBeDefined();
     expect(module.error).toBeDefined();
@@ -109,6 +116,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.Number);
+        assume(A.fields.field.type, FieldTypes.Number);
         expect(A.fields.field.type.min).toBe(38);
         expect(A.fields.field.type.max).toBe(138);
     });
@@ -143,6 +151,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.Number);
+        assume(A.fields.field.type, FieldTypes.Number);
         expect(A.fields.field.type.min).toBe(-200);
         expect(A.fields.field.type.max).toBe(200);
     });
@@ -156,6 +165,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.Choice);
+        assume(A.fields.field.type, FieldTypes.Choice);
         expect(A.fields.field.type.options).toEqual(["A", "B", "C"]);
     });
 
@@ -168,6 +178,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.Tag);
+        assume(A.fields.field.type, FieldTypes.Tag);
         expect(A.fields.field.type.options).toEqual(["A", "B", "C"]);
         expect(A.fields.field.type.dynamic).toBe(true);
     });
@@ -181,6 +192,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.Note);
+        assume(A.fields.field.type, FieldTypes.Note);
         expect(A.fields.field.type.typeNames).toEqual(["A", "B", "C"]);
     });
 
@@ -215,6 +227,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.List);
+        assume(A.fields.field.type, FieldTypes.List);
         expect(A.fields.field.type.type).toBeInstanceOf(FieldTypes.Note);
     });
 
@@ -227,6 +240,7 @@ type A {
 }
 `);
         expect(A.fields.field.type).toBeInstanceOf(FieldTypes.File);
+        assume(A.fields.field.type, FieldTypes.File);
         expect(A.fields.field.type.kind).toEqual("video");
         expect(A.fields.field.type.ext).toEqual(["avi", "mkv"]);
         expect(A.fields.field.type.folder).toEqual("attachments");
@@ -236,7 +250,7 @@ type A {
 });
 
 describe("style", () => {
-    const marginals = ["header", "footer"];
+    const marginals = ["header", "footer"] as const;
     for (let marginal of marginals) {
         test(`fn ${marginal}`, () => {
             let { A } = evaluateOTL(`
@@ -248,7 +262,8 @@ type A {
     }
 }
 `);
-            expect(A.style[marginal]).toBeDefined();
+            expect(A.style[marginal]).toBeInstanceOf(FnScript);
+            assume(A.style[marginal], FnScript);
             expect(A.style[marginal].call({})).toBeDefined();
         });
 
@@ -262,7 +277,8 @@ type A {
     }
 }
 `);
-            expect(A.style[marginal]).toBeDefined();
+            expect(A.style[marginal]).toBeInstanceOf(ExprScript);
+            assume(A.style[marginal], ExprScript);
             expect(A.style[marginal].call({})).toBeDefined();
         });
 
@@ -277,7 +293,8 @@ type A {
     }
 }
 `);
-            expect(A.style[marginal]).toBeDefined();
+            expect(A.style[marginal]).toBeInstanceOf(Values.Markdown);
+            assume(A.style[marginal], Values.Markdown);
             expect(A.style[marginal].source).toEqual("# Kek\n- one");
         });
     }
@@ -292,7 +309,7 @@ type A {
     }
 }
 `);
-        expect(A.style.link).toBeDefined();
+        expect(A.style.link).toBeInstanceOf(FnScript);
         expect(A.style.link.call({})).toBeDefined();
     });
 
@@ -306,7 +323,8 @@ type A {
     }
 }
 `);
-        expect(A.style.link).toBeDefined();
+        expect(A.style.link).toBeInstanceOf(ExprScript);
+        assume(A.style.link, ExprScript);
         expect(A.style.link.call({})).toBeDefined();
     });
 });
@@ -326,8 +344,8 @@ type A {
 `);
     expect(A).toBeDefined();
     expect(A.methods).toBeDefined();
-    expect(A.methods.one).toBeDefined();
-    expect(A.methods.inc).toBeDefined();
+    expect(A.methods.one).toBeInstanceOf(Method);
+    expect(A.methods.inc).toBeInstanceOf(Method);
 });
 
 test(`actions`, () => {
@@ -340,7 +358,7 @@ type A {
             script = fn"""
                 console.log("i am action one")
             """
-        }   
+        }
     }
 }
 `);
@@ -349,5 +367,5 @@ type A {
     expect(A.actions.one.id).toEqual("one");
     expect(A.actions.one.name).toEqual("Action One");
     expect(A.actions.one.icon).toEqual("far fa-fire");
-    expect(A.actions.one.script).toBeDefined();
+    expect(A.actions.one.script).toBeInstanceOf(FnScript);
 });

--- a/src/test/type.test.ts
+++ b/src/test/type.test.ts
@@ -5,9 +5,11 @@ import { dedent } from "src/utilities/dedent";
 
 beforeAll(async () => {
     gctx.testing = true;
+    // @ts-ignore
     let app = new App(new Vault("__vault__"));
     let plugin = new TypingPlugin(app, null);
     await plugin.onload();
+    // @ts-ignore
     await app.workspace.triggerLayoutReady();
 });
 


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.