### PR TITLE
types: Fix typing of `src/typing/**`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "esbuild-sass-plugin": "^2.12.0",
     "jest": "^29.6.2",
     "obsidian": "^1.1.1",
-    "obsidian-dataview": "^0.4.10",
+    "obsidian-dataview": "^0.5.68",
     "obsidian-plugin-cli": "^0.8.0",
     "postcss": "^8.4.27",
     "postcss-modules": "^6.0.0",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownView, Platform } from "obsidian";
-import { DataviewAPI } from "obsidian-dataview";
+import { DataviewApi} from "obsidian-dataview";
 import { Interpreter } from "src/language";
 import TypingPlugin from "src/main";
 import { ImportManager } from "src/scripting";
@@ -30,8 +30,8 @@ export class GlobalContext {
     get api(): TypingAPI {
         return this.plugin.api;
     }
-    get dv(): DataviewAPI {
-        if (this.testing) return {};
+    get dv(): DataviewApi {
+        if (this.testing) return {} as DataviewApi;
         return this.app.plugins.plugins.dataview?.api;
     }
     get currentNote(): Note | null {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownView, Platform } from "obsidian";
-import { DataviewApi} from "obsidian-dataview";
+import { DataviewApi } from "obsidian-dataview";
 import { Interpreter } from "src/language";
 import TypingPlugin from "src/main";
 import { ImportManager } from "src/scripting";

--- a/src/typing/field_type/base.tsx
+++ b/src/typing/field_type/base.tsx
@@ -35,7 +35,7 @@ export abstract class FieldType<InstanceType extends FieldType = any>
         return `${value}`;
     }
 
-    bind(context: FieldTypeBindingContext): InstanceType {
+    bind(this: InstanceType, context: FieldTypeBindingContext): InstanceType {
         let instance = this.copy();
         instance.context = context;
         return instance;

--- a/src/typing/field_type/base.tsx
+++ b/src/typing/field_type/base.tsx
@@ -42,7 +42,6 @@ export abstract class FieldType<InstanceType extends FieldType = any>
     }
 
     static ParametersVisitor: () => TVisitorBase<any>;
-    static ValueVisitor: TVisitorBase<any> = null;
 
     get isRelation(): boolean {
         return false;

--- a/src/typing/field_type/file.tsx
+++ b/src/typing/field_type/file.tsx
@@ -1,4 +1,5 @@
 import { TFile, TFolder, Vault } from "obsidian";
+import { Link } from "obsidian-dataview";
 import { gctx } from "src/context";
 import { Visitors } from "src/language";
 import { Script } from "src/scripting";
@@ -40,7 +41,7 @@ export class File extends FieldType<File> {
     @field()
     autorename: Script = null;
 
-    Display: FieldType["Display"] = ({ value }) => {
+    Display: FieldType["Display"] = ({ value }: { value: Link | string }) => {
         if (typeof value != "string") value = value.markdown();
         let { name, extension, display, path } = parseLinkExtended(value);
 

--- a/src/typing/field_type/note.tsx
+++ b/src/typing/field_type/note.tsx
@@ -1,3 +1,4 @@
+import { DataArray, Link, Literal, SMarkdownPage } from "obsidian-dataview";
 import { Suspense } from "react";
 import { gctx } from "src/context";
 import { Visitors } from "src/language";
@@ -38,8 +39,8 @@ export class Note extends FieldType<Note> {
         return this._types;
     }
 
-    Display: FieldType["Display"] = ({ value }) => {
-        if (typeof value != "string") value = value.markdown();
+    Display: FieldType["Display"] = ({ value }: { value: Link | string }) => {
+        if (typeof value !== "string") value = value.markdown();
         let { path, subpath, display } = parseLink(value);
         if (!display) {
             // to not pass empty linkText to RenderLink
@@ -63,7 +64,7 @@ export class Note extends FieldType<Note> {
         const preview = (value: string) => <this.Display value={value} />;
 
         let options: IComboboxOption[] = Array.from(
-            gctx.dv.pages(this.query).map(
+            (gctx.dv.pages(this.query) as DataArray<Record<string, Literal> & SMarkdownPage>).map(
                 (p): IComboboxOption => ({
                     value: this.short ? p.file.name : p.file.path,
                     label: p.file.name,

--- a/src/typing/field_type/number.tsx
+++ b/src/typing/field_type/number.tsx
@@ -1,5 +1,5 @@
 import { Visitors } from "src/language";
-import { Pickers } from "src/ui";
+import { IComboboxOption, Pickers } from "src/ui";
 import { field } from "src/utilities";
 import { FieldType } from "./base";
 
@@ -20,7 +20,7 @@ export class Number extends FieldType<Number> {
     };
 
     Picker = () => {
-        let options = [];
+        let options: IComboboxOption[] = [];
         for (let i = this.min; i <= this.max; i++) {
             options.push({ value: `${i}` });
         }

--- a/src/typing/note.tsx
+++ b/src/typing/note.tsx
@@ -1,5 +1,5 @@
 import { TFile } from "obsidian";
-import { LiteralValue } from "obsidian-dataview";
+import { Literal } from "obsidian-dataview";
 import { useRef } from "react";
 import { gctx } from "src/context";
 import { autoFieldAccessor, IFieldAccessor } from "src/middleware/field_accessor";
@@ -57,7 +57,7 @@ export class Note {
         return this._relations;
     }
 
-    get page(): Record<string, LiteralValue> {
+    get page(): Record<string, Literal> {
         let cached = gctx.noteCache.get(this.path, "page");
         if (cached) return cached;
 

--- a/src/typing/note.tsx
+++ b/src/typing/note.tsx
@@ -370,15 +370,15 @@ class FieldsProxy extends DataClass {
 
     refreshAccessor(): void {
         this.accessor = autoFieldAccessor(this.note.path, gctx.plugin);
-        let proxy = this;
+        let target = this;
 
         for (let fieldName in this.note.type.fields) {
             Reflect.defineProperty(this.proxy, fieldName, {
                 get: async function () {
-                    return proxy.getValue(fieldName);
+                    return target.getValue(fieldName);
                 },
                 set: async function (value: string | Promise<string>) {
-                    return proxy.setValue(fieldName, value);
+                    return target.setValue(fieldName, value);
                 },
             });
         }

--- a/src/typing/note.tsx
+++ b/src/typing/note.tsx
@@ -318,7 +318,7 @@ export class Note {
     }
 
     Link = ({ children, linkText, ...props }: { children?: any; linkText?: string }) => {
-        let ref = useRef();
+        let ref = useRef<HTMLAnchorElement>();
         return (
             <a
                 class="internal-link no-postprocessing"
@@ -423,7 +423,7 @@ export class NoteCache {
 
     startWatch() {
         gctx.plugin.registerEvent(
-            gctx.app.metadataCache.on("dataview:metadata-change", (op, file) => {
+            gctx.app.metadataCache.on("dataview:metadata-change", (op, file, _?) => {
                 if (gctx.graph.isReady) this.invalidate(file.path);
             })
         );

--- a/src/typing/prefix.ts
+++ b/src/typing/prefix.ts
@@ -1,4 +1,5 @@
-import { Platform, TFile, TFolder } from "obsidian";
+import { TFile, TFolder } from "obsidian";
+import { gctx } from "src/context";
 import { DataClass, field } from "src/utilities";
 import type { NoteState, Type } from ".";
 
@@ -112,7 +113,7 @@ export let INTERPOLATIONS: PrefixInterpolationSpec[] = [
         regex: () => "[1-9]+[0-9]*",
         fn: ({ type, index }) => {
             let max = 0;
-            let folder = app.vault.getAbstractFileByPath(type.folder);
+            let folder = gctx.app.vault.getAbstractFileByPath(type.folder);
             if (folder == null) {
                 // numeration starts with 1
                 return `${max + 1}`;

--- a/src/typing/style.ts
+++ b/src/typing/style.ts
@@ -1,4 +1,4 @@
-import { FnScript } from "src/scripting";
+import { FnScript, IScriptContextBase } from "src/scripting";
 import { DataClass, field } from "src/utilities";
 import { Values } from ".";
 
@@ -16,17 +16,17 @@ export enum HideInlineFieldsValues {
 
 export class Style extends DataClass {
     @field()
-    public link?: FnScript = null;
+    public link?: FnScript | null = null;
     @field()
-    public header?: FnScript | Values.Markdown = null;
+    public header?: FnScript | Values.Markdown | null = null;
     @field()
-    public footer?: FnScript | Values.Markdown = null;
+    public footer?: FnScript | Values.Markdown | null = null;
     @field()
     public show_prefix: ShowPrefixValues = ShowPrefixValues.SMART;
     @field()
-    public hide_inline_fields: HideInlineFieldsValues = null;
+    public hide_inline_fields: HideInlineFieldsValues | null = null;
     @field()
-    public css_classes: Array<string> = null;
+    public css_classes: Array<string> | null = null;
     @field()
-    public css: string = null;
+    public css: string | null = null;
 }

--- a/src/typing/type.tsx
+++ b/src/typing/type.tsx
@@ -9,19 +9,19 @@ export class Type extends DataClass {
     @field()
     public isAbstract: boolean = false;
     @field()
-    public name: string;
+    public name!: string;
     @field()
     public parentNames: Array<string> = [];
     @field({ inherit: false })
     public parents: Array<Type> = [];
     @field({ inherit: false })
-    public folder: string = null;
+    public folder: string | null = null;
     @field({ inherit: false })
-    public glob: string = null;
+    public glob: string | null = null;
     @field()
-    public icon: string = null;
+    public icon: string | null = null;
     @field()
-    public prefix: Prefix = null;
+    public prefix: Prefix | null = null;
     @field()
     public style: Style = Style.new();
     @field({ inherit: (a, b) => ({ ...b, ...a }) })
@@ -87,7 +87,7 @@ export class Type extends DataClass {
         return state;
     }
 
-    async create(state: NoteState | Promise<NoteState>) {
+    async create(state: Omit<NoteState, "type"> | Promise<Omit<NoteState, "type">>) {
         state = await state;
         if (!state) {
             return;

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,7 +16,7 @@ declare module "obsidian" {
     interface MetadataCache {
         on(name: "typing:schema-change", callback: () => any, ctx?: any): EventRef;
         on(name: "typing:schema-ready", callback: () => any, ctx?: any): EventRef;
-        on(name: "dataview:api-ready", callback: (api: DataviewPlugin["api"]) => any, ctx?: any): EventRef;
+        on(name: "dataview:api-ready", callback: (api: DataviewApi) => any, ctx?: any): EventRef;
         on(
             name: "dataview:metadata-change",
             callback: (


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.