### PR TITLE
types: Fix typing of `src/middleware/*`

### DIFF
--- a/src/middleware/css.tsx
+++ b/src/middleware/css.tsx
@@ -6,7 +6,7 @@ const VIEW_CONTAINER_SELECTORS = [".markdown-preview-view", ".markdown-source-vi
 
 let leafToClasses: Record<string, string[]> = {};
 
-const processLeaf = (leaf: WorkspaceLeaf) => {
+const processLeaf = (leaf: WorkspaceLeaf & { id: string }) => {
     let view = leaf.view;
     if (!(view instanceof MarkdownView)) {
         return;

--- a/src/middleware/file_creation_menu.tsx
+++ b/src/middleware/file_creation_menu.tsx
@@ -2,7 +2,7 @@ import { Plugin, TFolder } from "obsidian";
 
 export function registerFileCreationMenu(plugin: Plugin) {
     plugin.registerEvent(
-        plugin.app.workspace.on("file-menu", (menu, file, source, leaf) => {
+        plugin.app.workspace.on("file-menu", (menu, file, source, _leaf) => {
             if (source != "file-explorer-context-menu") return;
             if (!(file instanceof TFolder)) return;
             for (let extension of ["otl", "js", "jsx", "ts", "tsx"]) {
@@ -17,10 +17,10 @@ export function registerFileCreationMenu(plugin: Plugin) {
                             if (serial > 0) suffix = ` ${serial}`;
                             freeName = `${file.path}/Untitled${suffix}.${extension}`;
                             serial += 1;
-                        } while (this.app.vault.getAbstractFileByPath(freeName) != null);
+                        } while (plugin.app.vault.getAbstractFileByPath(freeName) !== null);
 
-                        let tfile = await this.app.vault.create(freeName, "");
-                        this.app.workspace.getLeaf(false).openFile(tfile);
+                        let tfile = await plugin.app.vault.create(freeName, "");
+                        plugin.app.workspace.getLeaf(false).openFile(tfile);
                     });
                 });
             }

--- a/src/middleware/link_rendering.tsx
+++ b/src/middleware/link_rendering.tsx
@@ -39,7 +39,7 @@ class LinkRenderChild extends MarkdownRenderChild {
             this.updateDebounced();
         }
     };
-    onSchemaChange = (op: "update", file: TFile) => {
+    onSchemaChange = () => {
         this.updateDebounced();
     };
     update = async () => {

--- a/src/middleware/link_rendering_live_preview.tsx
+++ b/src/middleware/link_rendering_live_preview.tsx
@@ -9,7 +9,7 @@ import {
     ViewUpdate,
     WidgetType,
 } from "@codemirror/view";
-import { editorInfoField, editorLivePreviewField, getLinkpath, Plugin, View } from "obsidian";
+import { editorInfoField, editorLivePreviewField, getLinkpath, Plugin, TFile, View } from "obsidian";
 import ReactDOM from "react-dom";
 import { gctx } from "src/context";
 import { RenderLink } from "src/utilities";
@@ -31,7 +31,7 @@ export class LinkWidget extends WidgetType {
 
         container.onmouseenter = (e) => {
             // ref: https://github.com/nothingislost/obsidian-hover-editor/blob/5df5230895d476f9777281e355d0dea1c577c974/src/main.ts#L266
-            let instance = gctx.app.workspace.getActiveViewOfType(View);
+            let instance = gctx.app.workspace.getActiveViewOfType(View) as { getFile?(): TFile; info?: { getFile(): TFile} };
             gctx.app.workspace.trigger("hover-link", {
                 event: e,
                 source: "editor",
@@ -43,7 +43,7 @@ export class LinkWidget extends WidgetType {
         };
 
         container.onclick = (e) => {
-            let instance = gctx.app.workspace.getActiveViewOfType(View);
+            let instance = gctx.app.workspace.getActiveViewOfType(View) as { getFile?(): TFile; info?: { getFile(): TFile} };
             let sourcePath = (instance.info ?? instance).getFile?.()?.path || "";
             let newLeaf = e.metaKey || e.ctrlKey;
             gctx.app.workspace.openLinkText(this.linkText, sourcePath, newLeaf);

--- a/src/middleware/marginal_rendering.tsx
+++ b/src/middleware/marginal_rendering.tsx
@@ -2,13 +2,14 @@ import styled from "@emotion/styled";
 import { around } from "monkey-around";
 import {
     EventRef,
+    Events,
     MarkdownPostProcessor,
     MarkdownPostProcessorContext,
     MarkdownPreviewView,
     MarkdownRenderChild,
     MarkdownRenderer,
 } from "obsidian";
-import { useState } from "react";
+import React, { useState } from "react";
 import { gctx } from "src/context";
 import TypingPlugin from "src/main";
 import { Script } from "src/scripting";
@@ -81,7 +82,7 @@ export class MarginalRenderChild extends MarkdownRenderChild {
     }
     onload() {
         this.registerEvent(
-            gctx.plugin.app.metadataCache.on("dataview:metadata-change", (op, file) => {
+            gctx.plugin.app.metadataCache.on("dataview:metadata-change", (op, file, _?) => {
                 if (!this.isAutoreloadEnabled) return;
                 if (file.path != this.path) return;
                 this.onMetadataChange();
@@ -120,7 +121,7 @@ export class MarginalRenderChild extends MarkdownRenderChild {
         this.hide();
         this.show();
     };
-    print = (...args) => {
+    print = (...args: any[]) => {
         this.messages.push(`${args}`);
     };
     show = async () => {
@@ -131,11 +132,11 @@ export class MarginalRenderChild extends MarkdownRenderChild {
                 container: this.containerEl,
                 component: this,
                 note: this.note,
-                render: (el) => render(el, this.containerEl),
+                render: (el: React.ReactNode) => render(el, this.containerEl),
                 print: this.print,
                 reload: () => this.requestUpdate(),
-                on: (event, handler) => {
-                    let eventRef = gctx.plugin.app.metadataCache.on(event, handler);
+                on: (event: string, handler: (...data: unknown[]) => unknown) => {
+                    let eventRef = (gctx.plugin.app.metadataCache as Events).on(event, handler);
                     this.deferredEvents.push(eventRef);
                     this.registerEvent(eventRef);
                     return eventRef;

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,4 +28,7 @@ declare module "obsidian" {
             ctx?: any
         ): EventRef;
     }
+    interface MarkdownPostProcessorContext {
+        containerEl?: HTMLElement;
+    }
 }


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.