### PR TITLE
types: Fix a number of issues in `src/language/*`

### DIFF
--- a/src/language/interpreter/interpreter.ts
+++ b/src/language/interpreter/interpreter.ts
@@ -19,6 +19,11 @@ export class Interpreter extends ModuleManagerSync {
     }
 
     public evaluateModule(file: FileSpec, mod: Module): boolean {
+        if (file.source === null || file.source === undefined) {
+            setPanelContent(`Importing ${this.activeModule?.file.path} failed...`);
+            return false;
+        }
+
         setPanelContent(`Importing ${this.activeModule?.file.path}...`);
         let tree = parser.parse(file.source);
 

--- a/src/language/interpreter/interpreter.ts
+++ b/src/language/interpreter/interpreter.ts
@@ -50,7 +50,7 @@ export class Interpreter extends ModuleManagerSync {
     }
 
     protected onAfterPreload(): void {
-        this.importModule(gctx.plugin.settings.schemaPath, null, true);
+        this.importModule(gctx.plugin.settings.schemaPath, undefined, true);
         gctx.graph.isReady = true;
         gctx.noteCache.invalidateAll();
         gctx.app.metadataCache.trigger("typing:schema-ready");

--- a/src/language/visitors/composite/attribute.ts
+++ b/src/language/visitors/composite/attribute.ts
@@ -36,8 +36,9 @@ export const NamedAttribute = (valueType: TVisitorBase) =>
         },
         symbols(node) {
             let nameNode = node.getChild(Rules.AssignmentName);
-            if (!nameNode) return;
+            if (!nameNode) return null;
             let name = this.children.name.run(nameNode);
+            if (!name) return null;
             return [{ name, nameNode, node }];
         },
     });

--- a/src/language/visitors/composite/field.ts
+++ b/src/language/visitors/composite/field.ts
@@ -170,8 +170,13 @@ export const Field = () =>
             }),
         },
         run(): FieldObject {
-            let opts = this.runChildren();
-            return FieldObject.new(opts);
+            let { name, type, default: defaultValue, ...opts } = this.runChildren();
+            return FieldObject.new({
+                name: name ?? undefined,
+                type: type ?? undefined,
+                default: defaultValue ?? undefined,
+                ...opts
+            });
         },
         symbols(node) {
             let nameNode = node.getChild(Rules.AssignmentName);

--- a/src/language/visitors/composite/field.ts
+++ b/src/language/visitors/composite/field.ts
@@ -23,7 +23,7 @@ const createKwargChildren = (kwargs: Record<string, TVisitorBase>) => {
                 return this.runChildren()["value"];
             },
             symbols(node) {
-                return [{ name: key, node: node, nameNode: node.getChild(Rules.ParameterName) }];
+                return [{ name: key, node: node, nameNode: node.getChild(Rules.ParameterName)! }];
             },
         });
     }
@@ -88,7 +88,7 @@ export const ParametersVisitorFactory = <Arg extends TVisitorBase, Kwargs extend
                     }
                     if (child != argVisitor) {
                         metKwarg = true;
-                        for (let symbol of child.symbols(node)) {
+                        for (let symbol of child.symbols(node)!) {
                             if (kwargsSet.has(symbol.name)) {
                                 repeatedKwargs.push(symbol.node);
                             }

--- a/src/language/visitors/composite/field.ts
+++ b/src/language/visitors/composite/field.ts
@@ -141,10 +141,12 @@ export const FieldType = () =>
         },
         run(node): FieldTypeObject {
             let name = this.runChildren({ keys: ["name"] })["name"];
-            let paramsVisitor = ((FieldTypes as any)[name] as typeof FieldTypeObject).ParametersVisitor();
+            // TODO: Graceful recovery by returning an InvalidType sentinel value?
+            if (!name) throw new Error("Failed to parse field type");
+            let paramsVisitor = FieldTypes[name as keyof typeof FieldTypes].ParametersVisitor();
             let params = node.getChild(Rules.ParameterList);
             if (!params) {
-                return (FieldTypes as any)[name].new({});
+                return FieldTypes[name as keyof typeof FieldTypes].new({});
             }
             return paramsVisitor.run(params);
         },

--- a/src/language/visitors/composite/import.ts
+++ b/src/language/visitors/composite/import.ts
@@ -54,8 +54,9 @@ export const Import = () =>
                 this.error(`Error importing ${path}:\n${module.error}`);
                 return;
             }
-            for (let symbol of symbols) {
-                if (!(symbol.symbol in module.env)) {
+            // TODO: Review handling of null/undefined
+            for (let symbol of symbols!) {
+                if (!(symbol!.symbol! in module!.env!)) {
                     this.error("Unknown symbol", symbol.node);
                 }
             }
@@ -64,12 +65,13 @@ export const Import = () =>
             let result: Type[] = [];
             let { symbols, path } = this.runChildren();
             let module = this.callContext.interpreter.importSmart(path, this.callContext.path);
-            for (let symbol of symbols) {
-                if (!(symbol.symbol in module.env)) {
+            // TODO: Review handling of null/undefined
+            for (let symbol of symbols!) {
+                if (!(symbol.symbol! in module!.env!)) {
                     // TODO: handle: throw error or continue
                     continue;
                 }
-                let importedType = module.env[symbol.symbol];
+                let importedType = module!.env![symbol!.symbol!];
                 importedType.name = symbol.alias;
                 result.push(importedType);
             }

--- a/src/language/visitors/composite/import.ts
+++ b/src/language/visitors/composite/import.ts
@@ -77,6 +77,7 @@ export const Import = () =>
         },
         symbols() {
             let symbols = this.runChildren({ keys: ["symbols"] })["symbols"];
+            if (!symbols) return null;
             return symbols.map((x) => ({ nameNode: x.node, node: x.node, name: x.alias }));
         },
     });

--- a/src/language/visitors/composite/import.ts
+++ b/src/language/visitors/composite/import.ts
@@ -4,8 +4,8 @@ import { createVisitor, Rules } from "../index_base";
 import * as Visitors from "../pure";
 
 interface ImportSymbol {
-    symbol: string;
-    alias: string;
+    symbol?: string;
+    alias?: string;
     node: SyntaxNode;
 }
 
@@ -30,8 +30,8 @@ export const Import = () =>
                 run(node) {
                     let result: ImportSymbol[] = [];
                     this.traverse((node, child) => {
-                        let { symbol, alias } = child.run(node);
-                        result.push({ alias: alias ?? symbol, symbol, node });
+                        let { symbol, alias } = child.run(node)!;
+                        result.push({ alias: alias ?? symbol ?? undefined, symbol: symbol ?? undefined, node });
                     });
                     return result;
                 },

--- a/src/language/visitors/composite/section.ts
+++ b/src/language/visitors/composite/section.ts
@@ -8,7 +8,7 @@ export const Section = <V extends TVisitorBase>(name: string, member: V, info?: 
         rules: Rules.SectionDeclaration,
         accept(node) {
             let nameNode = node.getChild(Rules.Identifier);
-            if (!nameNode) return;
+            if (!nameNode) return false;
             return this.children.name.run(nameNode) == name;
         },
         children: {
@@ -43,7 +43,9 @@ export const Section = <V extends TVisitorBase>(name: string, member: V, info?: 
         },
         symbols(node) {
             let nameNode = node.getChild(Rules.Identifier);
+            if (!nameNode) return null;
             let name = this.children.name.run(nameNode);
+            if (!name) return null;
             return [{ name, nameNode, node }];
         },
         run(node) {
@@ -56,7 +58,7 @@ export const StructuredSection = <Children extends TChildrenBase>(name: string, 
         rules: Rules.SectionDeclaration,
         accept(node) {
             let nameNode = node.getChild(Rules.Identifier);
-            if (!nameNode) return;
+            if (!nameNode) return false;
             return this.children.name.run(nameNode) == name;
         },
         children: {
@@ -86,7 +88,9 @@ export const StructuredSection = <Children extends TChildrenBase>(name: string, 
         },
         symbols(node) {
             let nameNode = node.getChild(Rules.Identifier);
+            if (!nameNode) return null;
             let name = this.children.name.run(nameNode);
+            if (!name) return null;
             return [{ name, nameNode, node }];
         },
         run(node) {

--- a/src/language/visitors/composite/tagged_string.ts
+++ b/src/language/visitors/composite/tagged_string.ts
@@ -11,14 +11,14 @@ export const TaggedString = ({ tags, strict = false }: { tags: string[]; strict?
     createVisitor({
         rules: Rules.TaggedString,
         accept(node) {
-            if (!strict) {
-                return true;
-            }
+            if (!strict) return true;
             let nodeTag = node.getChild(Rules.Tag);
+            if (!nodeTag) return false;
             return tags.contains(this.getNodeText(nodeTag));
         },
         lint(node) {
             let nodeTag = node.getChild(Rules.Tag);
+            if (!nodeTag) return;
             let tag = this.getNodeText(nodeTag);
 
             if (!tags.contains(tag)) {
@@ -55,12 +55,12 @@ export const FnScriptString = (content = "\n\t${}\n", tags = ["fn", "function"])
         run(node) {
             if (!gctx.settings.enableScripting) return undefined;
             return FnScript.new({
-                source: dedent(this.runChild("code")),
+                source: dedent(this.runChild("code") ?? ""),
                 filePath: this.globalContext?.callContext?.interpreter?.activeModule?.file?.path,
             });
         },
         lint(node) {
-            let result = FnScript.validate(this.runChild("code"));
+            let result = FnScript.validate(this.runChild("code") ?? "");
             if (!gctx.settings.enableScripting) {
                 this.warning(
                     "Safe mode: JS scripting is currently disabled. Until you enable it in the plugin settings, this expression will be ignored.",
@@ -93,12 +93,12 @@ export const ExprScriptString = (content = "\n\t${}\n", tags = ["expr", "express
         run(node) {
             if (!gctx.settings.enableScripting) return undefined;
             return ExprScript.new({
-                source: dedent(this.runChild("code")),
+                source: dedent(this.runChild("code") ?? ""),
                 filePath: this.globalContext?.callContext?.interpreter?.activeModule?.file?.path,
             });
         },
         lint(node) {
-            let result = ExprScript.validate(this.runChild("code"));
+            let result = ExprScript.validate(this.runChild("code") ?? "");
             if (!gctx.settings.enableScripting) {
                 this.warning(
                     "Safe mode: JS scripting is currently disabled. Until you enable it in the plugin settings, this expression will be ignored.",
@@ -129,7 +129,7 @@ export const MarkdownString = (tags = ["md", "markdown"]) =>
             code: Visitors.String,
         },
         run(node) {
-            return new Values.Markdown(dedent(this.runChild("code")));
+            return new Values.Markdown(dedent(this.runChild("code") ?? ""));
         },
         snippets() {
             return [

--- a/src/language/visitors/pure/identifier.ts
+++ b/src/language/visitors/pure/identifier.ts
@@ -44,6 +44,7 @@ export const Identifier = (opts?: { allowString: boolean }) =>
                 eager: true,
                 traversalOptions: { visitTop: true, visitChildren: true },
             });
-            return result["identifier"] ?? result["stringIdentifier"];
+            // TODO: Review whether returning "" is safe
+            return result["identifier"] ?? result["stringIdentifier"] ?? "";
         },
     });

--- a/src/language/visitors/pure/proxy.ts
+++ b/src/language/visitors/pure/proxy.ts
@@ -1,20 +1,23 @@
-import { createVisitor, Rules, TVisitorBase } from "../index_base";
+import { createVisitor, Rules, TUtilsBase, TVisitorBase, Visitor } from "../index_base";
 
-export const Proxy = <R>(proxyRules: Rules | Rules[], visitor: TVisitorBase<R>) =>
+export const Proxy = <V extends TVisitorBase>(proxyRules: Rules | Rules[], visitor: V):
+    Visitor<ReturnType<V["run"]>, {
+        visitor: V;
+    }, TUtilsBase, unknown, TVisitorBase<any, any, any, any>> =>
     createVisitor({
         rules: proxyRules,
         children: { visitor },
         accept(node) {
-            return visitor.accept(node.firstChild);
+            return visitor.accept(node?.firstChild!);
         },
         run(node) {
-            return visitor.run(node.firstChild);
+            return visitor.run(node?.firstChild!) as ReturnType<V["run"]>;
         },
         lint(node) {
-            return visitor.lint(node.firstChild);
+            return visitor.lint(node?.firstChild!);
         },
         complete(node, context) {
-            return visitor.complete(node.firstChild, context);
+            return visitor.complete(node?.firstChild!, context);
         },
         snippets() {
             return visitor.snippets();

--- a/src/language/visitors/pure/scope.ts
+++ b/src/language/visitors/pure/scope.ts
@@ -13,7 +13,7 @@ export const Scope = <R, C extends TChildrenBase>(
             let symbols = [] as Symbol[];
             this.traverse((_, visitor) => {
                 visitor.traverse((node, child) => {
-                    for (let symbol of child.symbols(node)) {
+                    for (let symbol of child.symbols(node)!) {
                         symbols.push(symbol);
                     }
                 });
@@ -36,7 +36,7 @@ export const Scope = <R, C extends TChildrenBase>(
             }
 
             let set = new Set();
-            for (let symbol of this.symbols(node)) {
+            for (let symbol of this.symbols(node)!) {
                 if (set.has(symbol.name)) {
                     this.error(`Duplicate symbol: ${symbol.name}`, symbol.nameNode);
                 }
@@ -49,7 +49,7 @@ export const Scope = <R, C extends TChildrenBase>(
             for (let key in visitor.children) {
                 result.push(...visitor.children[key].snippets());
             }
-            let symbols = this.symbols(node).map((x) => x.name);
+            let symbols = this.symbols(node)!.map((x) => x.name);
             result = result.filter((x) => !x.symbol || !symbols.contains(x.symbol));
             for (let i = 0; i < result.length; i++) {
                 result[i].boost = -i;

--- a/src/language/visitors/pure/scope.ts
+++ b/src/language/visitors/pure/scope.ts
@@ -5,6 +5,7 @@ export const Scope = <R, C extends TChildrenBase>(
     opts?: { shouldComplete: boolean }
 ): TVisitorBase<R> => {
     let options: typeof opts = opts ?? { shouldComplete: true };
+    // TODO: Review whether we can remove the type assertion;
     return createVisitor({
         rules: visitor.rules,
         tags: ["scope"],
@@ -67,5 +68,5 @@ export const Scope = <R, C extends TChildrenBase>(
             // TODO: fix back
             cache: { lint: false, run: false, complete: false },
         },
-    });
+    }) as TVisitorBase<R>;
 };

--- a/src/language/visitors/pure/scope.ts
+++ b/src/language/visitors/pure/scope.ts
@@ -4,7 +4,7 @@ export const Scope = <R, C extends TChildrenBase>(
     visitor: TVisitorBase<R, C>,
     opts?: { shouldComplete: boolean }
 ): TVisitorBase<R> => {
-    let options: typeof opts = opts ?? { shouldComplete: opts?.shouldComplete ?? true };
+    let options: typeof opts = opts ?? { shouldComplete: true };
     return createVisitor({
         rules: visitor.rules,
         tags: ["scope"],

--- a/src/language/visitors/pure/scope.ts
+++ b/src/language/visitors/pure/scope.ts
@@ -11,7 +11,7 @@ export const Scope = <R, C extends TChildrenBase>(
         tags: ["scope"],
         children: { visitor },
         symbols() {
-            let symbols = [] as Symbol[];
+            let symbols: Symbol[] = [];
             this.traverse((_, visitor) => {
                 visitor.traverse((node, child) => {
                     for (let symbol of child.symbols(node)!) {

--- a/src/language/visitors/pure/union.ts
+++ b/src/language/visitors/pure/union.ts
@@ -24,8 +24,10 @@ export const Union = <
             let values = this.runChildren();
             for (let key in values) {
                 // return first accepted value
-                return values[key as keyof typeof this.children];
+                return values[key as keyof typeof this.children] as R;
             }
+            // TODO: Is this safe?
+            return null as any;
         },
         snippets() {
             let result = [];

--- a/src/language/visitors/toplevel/file.ts
+++ b/src/language/visitors/toplevel/file.ts
@@ -15,7 +15,8 @@ export const File = createVisitor({
         let module: Record<string, TypeObject> = {};
         this.traverse((node, child) => {
             let types = child.run(node);
-            for (let type of types) {
+            // TODO: Review this and see if we can get rid of "types as any"
+            for (let type of types as any) {
                 module[type.name] = type;
                 if (!type.parentNames) continue;
                 // NOTE: the order of inheritance is correct because a type has to be defined below its parents

--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -47,6 +47,7 @@ export const TypeParentsClause = createVisitor({
         let result: string[] = [];
         this.traverse((node, child) => {
             let name = child.run(node);
+            if (!name) return;
             result.push(name);
         });
         return result;
@@ -75,6 +76,7 @@ export const TypeParentsClause = createVisitor({
         let res: Symbol[] = [];
         this.traverse((node, child) => {
             let name = child.run(node);
+            if (!name) return;
             res.push({ node, nameNode: node, name: name });
         });
         return res;
@@ -287,7 +289,9 @@ export const Type = createVisitor({
     },
     symbols(node) {
         let nameNode = node.getChild(Rules.LooseIdentifier);
+        if (!nameNode) return null;
         let name = this.children.name.run(nameNode);
+        if (!name) return null;
         return [{ name, nameNode, node }];
     },
 });

--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -1,5 +1,6 @@
 import { Completion, snippet, snippetCompletion } from "@codemirror/autocomplete";
 import { Decoration, WidgetType } from "@codemirror/view";
+import { SyntaxNode } from "@lezer/common";
 import { Action, Field, Hook, HookContainer, Method, Prefix, Style, Type as TypeObject } from "src/typing";
 import { stripQuotes } from "src/utilities";
 import * as Visitors from "../composite";
@@ -84,8 +85,10 @@ export const TypeParentsClause = createVisitor({
     utils: {
         globalSymbols() {
             let globalScope = this.getParent({ tags: ["scope"] });
-            let globalScopeNode = this.node;
-            while (globalScopeNode.name != Rules.File) globalScopeNode = globalScopeNode.parent;
+            if (!globalScope) throw new Error("Failed to get global symbols: Not within a scope");
+            let globalScopeNode: SyntaxNode | null = this.node;
+            while (globalScopeNode && globalScopeNode.name != Rules.File) globalScopeNode = globalScopeNode.parent;
+            if (!globalScopeNode) throw new Error("Failed to get global symbols: Not within a scope");;
             return globalScope.symbols(globalScopeNode) ?? [];
         },
     },

--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -54,7 +54,7 @@ export const TypeParentsClause = createVisitor({
         return result;
     },
     complete(node) {
-        let currentParents = this.symbols(node).map((x) => x.name);
+        let currentParents = this.symbols(node)!.map((x) => x.name);
         return this.utils
             .globalSymbols()
             .filter((x: Symbol) => x.node.to < node.from)

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -958,6 +958,30 @@ export class Visitor<
     runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
         call: K,
         args: Parameters<NonNullable<Args[K]>>,
+        defaultReturn: ReturnType<NonNullable<Args[K]>>
+    ): ReturnType<NonNullable<Args[K]>>;
+
+    runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
+        call: K,
+        args: Parameters<NonNullable<Args[K]>>,
+        defaultReturn: null
+    ): ReturnType<NonNullable<Args[K]>> | null;
+
+    runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
+        call: K,
+        args: Parameters<NonNullable<Args[K]>>,
+        defaultReturn: undefined
+    ): ReturnType<NonNullable<Args[K]>> | undefined;
+
+    runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
+        call: K,
+        args: Parameters<NonNullable<Args[K]>>,
+        defaultReturn?: ReturnType<NonNullable<Args[K]>>
+    ): ReturnType<NonNullable<Args[K]>> | undefined;
+
+    runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
+        call: K,
+        args: Parameters<NonNullable<Args[K]>>,
         defaultReturn?: ReturnType<NonNullable<Args[K]>>
     ): ReturnType<NonNullable<Args[K]>> | undefined {
         const func = this.args[call] as null | undefined | ((...args: Parameters<NonNullable<Args[K]>>) => ReturnType<NonNullable<Args[K]>>);

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -953,17 +953,16 @@ export class Visitor<
         args: Parameters<Args[K]>,
         defaultReturn?: ReturnType<Args[K]>
     ): ReturnType<Args[K]> {
-        let result = defaultReturn;
         const func = this.args[call] as (...args: Parameters<Args[K]>) => ReturnType<Args[K]>;
-        if (func != null) {
+        if (func !== null && func !== undefined) {
             try {
-                result = func(...args); // as ReturnType<this["args"][K]>;
+                return func(...args);
             } catch (e) {
                 log.error(`runFunc ${call} error`, { e, call, args, defaultReturn, func, this: this });
                 this.error(`Visitor.${call}() failed.`);
             }
         }
-        return result;
+        return defaultReturn;
     }
 }
 

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -112,7 +112,7 @@ export interface VisitorArgs<
     Children extends TChildrenBase,
     Utils extends TUtilsBase,
     CacheType extends TCacheBase,
-    Super extends TVisitorBase,
+    Super extends TOptionalVisitorBase,
     This = Visitor<Return, Children, Utils, CacheType, Super>
 > {
     // TODO: probably should rename to `node`(s) or `nodetype`(s) or `nodeType`(s), `Rules` -> `NodeType`
@@ -155,14 +155,17 @@ export type TVisitorArgsBase<
     Children extends TChildrenBase = any,
     Utils extends TUtilsBase = any,
     CacheType extends TCacheBase = any
-> = VisitorArgs<Return, Children, Utils, CacheType, null, TVisitorBase>;
+> = VisitorArgs<Return, Children, Utils, CacheType, TNoVisitor, TVisitorBase>;
 
 export type TVisitorBase<
     Return extends TReturnBase = any,
     Children extends TChildrenBase = any,
     Utils extends TUtilsBase = any,
     CacheType extends TCacheBase = any
-> = Visitor<Return, Children, Utils, CacheType, TVisitorBase>;
+> = Visitor<Return, Children, Utils, CacheType, TOptionalVisitorBase>;
+
+type TOptionalVisitorBase = TVisitorBase;
+type TNoVisitor = any;
 
 type VisitorReturn<Key extends keyof Children, Children extends TChildrenBase> =
     Partial<{ [K in Key]: ReturnType<Children[K]["run"]> }>;
@@ -172,16 +175,16 @@ export class Visitor<
     Children extends TChildrenBase,
     Utils extends TUtilsBase,
     CacheType extends TCacheBase,
-    Super extends TVisitorBase
+    Super extends TOptionalVisitorBase
 > extends DataClass {
     @field()
-    args: VisitorArgs<Return, Children, Utils, CacheType, Super>;
+    args!: VisitorArgs<Return, Children, Utils, CacheType, Super, any>;
 
-    super: Super;
-    derived: TVisitorBase;
+    super: Super = null as any;
+    derived?: TVisitorBase;
     isInitialized: boolean = false;
 
-    originalArgs: VisitorArgs<Return, Children, Utils, CacheType, Super>;
+    originalArgs!: VisitorArgs<Return, Children, Utils, CacheType, Super, any>;
     hasDecorations: boolean = false;
     childrenWithDecorations: (keyof Children)[] = [];
     hasHover: boolean = false;
@@ -926,7 +929,7 @@ export class Visitor<
 
     // } CACHE
 
-    getParent<R extends Rules>({ tags, rules }: { tags?: string[]; rules?: R }): VisitorWithRule<R> {
+    getParent<R extends Rules>({ tags, rules }: { tags?: string[]; rules?: R }): TVisitorBase | null {
         for (let i = this.globalContext.callStack.length - 1; i >= 0; i--) {
             let visitor = this.globalContext.callStack[i].visitor;
             if (tags && visitor.tags) {

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -401,9 +401,9 @@ export class Visitor<
         return this.globalContext.callContext;
     }
 
-    setCallContext(callContext?: GlobalCallContext): boolean {
-        if (callContext == null) {
-            return true;
+    setCallContext(callContext?: GlobalCallContext) {
+        if (callContext === null || callContext === undefined) {
+            return;
         }
 
         // TODO: temporarily flush cache each call
@@ -630,7 +630,7 @@ export class Visitor<
 
         let result = {} as VisitorReturn<Key, Children>;
         let traversalOptions = { ...options.traversalOptions };
-        traversalOptions.selectChildren = options?.keys;
+        traversalOptions.selectChildren = options?.keys ?? undefined;
 
         let fulfilledKeys: Set<Key>;
         if (options?.eager) {
@@ -642,7 +642,7 @@ export class Visitor<
 
         this.traverse((node, child, key) => {
             let res = child.run(node);
-            if (res != null) {
+            if (res !== null && res !== undefined) {
                 result[key] = res;
                 if (options?.eager) fulfilledKeys.add(key);
             }
@@ -655,7 +655,7 @@ export class Visitor<
     }
 
     snippets(): CompletionEntry[] {
-        return this.runFunc("snippets", [], []);
+        return this.runFunc("snippets", [], null) ?? [];
     }
 
     symbols(node: NodeType): Symbol[] | null {
@@ -663,11 +663,11 @@ export class Visitor<
         let cached = this.getCachedResult("symbols");
         if (cached !== undefined) return cached;
 
-        let result = this.runFunc("symbols", [node], null);
+        let result = this.runFunc("symbols", [node]);
 
-        this.cacheResult("symbols", result);
+        this.cacheResult("symbols", result ?? undefined);
         this.exit();
-        return result;
+        return result ?? null;
     }
 
     rebase(node: NodeType): NodeType {
@@ -795,7 +795,7 @@ export class Visitor<
         this.cacheContainer().diagnostics.push(...diagnostics);
     }
 
-    diagnostics(severity: "error" | "warning" | "info", message: string | Partial<Diagnostic>, node?: NodeType) {
+    diagnostics(severity: "error" | "warning" | "info", message: string | Partial<Diagnostic>, node?: NodeType | null) {
         node = node ?? this.node;
         let diagnostic: Partial<Diagnostic>;
         if (typeof message == "string") {
@@ -809,16 +809,16 @@ export class Visitor<
         this.cacheContainer().diagnostics.push(diagnostic as Diagnostic);
     }
 
-    error(message: string | Partial<Diagnostic>, node?: NodeType) {
+    error(message: string | Partial<Diagnostic>, node?: NodeType | null) {
         // TODO: path?
         this.diagnostics("error", message, node);
     }
 
-    warning(message: string | Partial<Diagnostic>, node?: NodeType) {
+    warning(message: string | Partial<Diagnostic>, node?: NodeType | null) {
         this.diagnostics("warning", message, node);
     }
 
-    info(message: string | Partial<Diagnostic>, node?: NodeType) {
+    info(message: string | Partial<Diagnostic>, node?: NodeType | null) {
         this.diagnostics("info", message, node);
     }
 

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -639,7 +639,7 @@ export class Visitor<
         if (options?.eager) {
             fulfilledKeys = new Set();
             traversalOptions.exitCriterion = () => {
-                return fulfilledKeys.size == options?.keys.length;
+                return fulfilledKeys.size === options?.keys?.length;
             };
         }
 
@@ -849,7 +849,7 @@ export class Visitor<
         if (this.callContext.input) return this.callContext.input.slice(node.from, node.to);
         if (this.callContext.doc) return this.callContext.doc.sliceString(node.from, node.to);
         if (this.callContext.state) return this.callContext.state.sliceDoc(node.from, node.to);
-        if (this.callContext.interpreter)
+        if (this.callContext.interpreter?.activeModule)
             return this.callContext.interpreter.activeModule.file.source.slice(node.from, node.to);
         throw Error();
     }
@@ -878,8 +878,8 @@ export class Visitor<
         return undefined;
     }
 
-    cacheResult<K extends keyof VisitorOptions["cache"]>(call: K, result: CacheEntry["callCache"][K]) {
-        let shouldUseCache = this.options.cache[call];
+    cacheResult<K extends keyof NonNullable<VisitorOptions["cache"]>>(call: K, result: CacheEntry["callCache"][K]) {
+        let shouldUseCache = this.options.cache?.[call];
         if (shouldUseCache) {
             this.callCache[call] = result;
         }
@@ -953,10 +953,10 @@ export class Visitor<
 
     runFunc<K extends CallType, Args extends VisitorArgs<Return, Children, Utils, CacheType, Super>>(
         call: K,
-        args: Parameters<Args[K]>,
-        defaultReturn?: ReturnType<Args[K]>
-    ): ReturnType<Args[K]> {
-        const func = this.args[call] as (...args: Parameters<Args[K]>) => ReturnType<Args[K]>;
+        args: Parameters<NonNullable<Args[K]>>,
+        defaultReturn?: ReturnType<NonNullable<Args[K]>>
+    ): ReturnType<NonNullable<Args[K]>> | undefined {
+        const func = this.args[call] as null | undefined | ((...args: Parameters<NonNullable<Args[K]>>) => ReturnType<NonNullable<Args[K]>>);
         if (func !== null && func !== undefined) {
             try {
                 return func(...args);

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -109,8 +109,7 @@ const defaultVisitorOptions: VisitorOptions = {
 export interface VisitorArgs<
     Return extends TReturnBase,
     Children extends TChildrenBase,
-    Utils extends Record<string, (this: This, ...args: any) => any>,
-    // Utils extends { [name: string]: (this: This, ...args: any) => any },
+    Utils extends TUtilsBase,
     CacheType extends TCacheBase,
     Super extends TVisitorBase,
     This = Visitor<Return, Children, Utils, CacheType, Super>
@@ -139,7 +138,7 @@ export interface VisitorArgs<
     decorations?: (this: This, node: NodeType, view: EditorView) => Range<Decoration>[];
 
     children?: Children;
-    utils?: Utils;
+    utils?: Utils & ThisType<This>;
 
     options?: VisitorOptions;
     // cache?: () => CacheType;

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -199,13 +199,14 @@ export class Visitor<
         return this.args.tags;
     }
     get children() {
-        return this.args.children;
+        return this.args.children!;
     }
     get utils() {
-        return this.args.utils;
+        return this.args.utils!;
     }
     get options() {
-        return this.args.options;
+        // TODO: This is not correct, this.args.options may actually be undefined
+        return this.args.options!;
     }
 
     static fromArgs<
@@ -384,7 +385,8 @@ export class Visitor<
     static globalContexts: GlobalContext[] = [];
 
     get globalContext() {
-        return Visitor.globalContexts.last();
+        // TODO: Assert that a traversal is in progress and thus globalContexts is not empty
+        return Visitor.globalContexts.last()!;
     }
 
     get localContext() {

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -69,7 +69,7 @@ interface GlobalCallContext {
 interface GlobalContext {
     callStack: StackFrame[];
     callContext: GlobalCallContext;
-    callCount: Record<string, number>;
+    callCount: Partial<Record<string, number>>;
 }
 
 interface LocalContext {

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -226,7 +226,9 @@ export class Visitor<
         args: VisitorArgs<Return2, Children2, Utils2, CacheType2, Super, This>
     ): Visitor<Return2, Children2, Utils2, CacheType2, Super> {
         return Visitor.new<Visitor<Return2, Children2, Utils2, CacheType2, Super>>({
-            args: args,
+            // Ignore the fact that `This` might be different type
+            // than the one specified in the type parameter default
+            args: args as any,
         });
     }
 
@@ -258,8 +260,8 @@ export class Visitor<
         >
     >(args: VisitorArgs<Return2, Children2, Utils2, CacheType2, NewThis>) {
         let newArgs = Object.assign({}, this.originalArgs, args);
-        let result = Visitor.fromArgs<Return2, Children2, Utils2, CacheType2, NewSuper>(newArgs);
-        result.super = Visitor.fromArgs<Return, Children, Utils, CacheType, Super>(this.originalArgs) as NewSuper;
+        let result = Visitor.fromArgs<Return2, Children2, Utils2, CacheType2, NewSuper>(newArgs as any);
+        result.super = Visitor.fromArgs<Return, Children, Utils, CacheType, Super>(this.originalArgs as any) as NewSuper;
         result.super.derived = result;
         result.super.bind(result);
         return result;

--- a/src/language/visitors/wrappers/scope.ts
+++ b/src/language/visitors/wrappers/scope.ts
@@ -25,7 +25,7 @@ export const ScopeWrapper = ({ shouldComplete = true }: { shouldComplete: boolea
             }
 
             let set = new Set();
-            for (let symbol of this.symbols(node)) {
+            for (let symbol of this.symbols(node)!) {
                 if (set.has(symbol.name)) {
                     this.error(`Duplicate symbol: ${symbol.name}`, symbol.nameNode);
                 }
@@ -40,7 +40,7 @@ export const ScopeWrapper = ({ shouldComplete = true }: { shouldComplete: boolea
             for (let key in this.children) {
                 result.push(...this.children[key].snippets());
             }
-            let symbols = this.symbols(node).map((x) => x.name);
+            let symbols = this.symbols(node)!.map((x) => x.name);
             result = result.filter((x) => !x.symbol || !symbols.contains(x.symbol));
             for (let i = 0; i < result.length; i++) {
                 result[i].boost = -i;


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.

All usages of the definite assignment operator (i.e. <code><em>&lt;expr&gt;</em>!</code>) in this PR should be reviewed (and possibly removed) at a later date.