### PR TITLE
types: Fix typing of `src/scripting/**`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import { Visitors } from "src/language";
 import { Note, Type } from "src/typing";
 import * as ui from "src/ui";
 import { TypeSuggestModal } from "src/ui";
+import { Module } from "src/utilities/module_manager_sync";
 
 type PromiseType<T> = T extends Promise<infer U> ? U : never;
 
@@ -56,10 +57,10 @@ export class TypingAPI {
 
     import(path: string): Record<string, any> {
         let mod = gctx.importManager.importSmart(path);
-        if (mod == null) {
+        if (mod === null || mod === undefined) {
             throw new Error(`ImportError: Could not find module ${path}`);
         }
-        if (mod.error != null) {
+        if (mod.error !== null && mod.error !== undefined) {
             throw new Error(`ImportError: Error in module ${path}: ${mod.error}`);
         }
         return mod.env;
@@ -70,10 +71,10 @@ export class TypingAPI {
             return this.lib[path as keyof typeof this.lib]!;
         }
         let mod = gctx.importManager.importSmart(path, base);
-        if (mod == null) {
+        if (mod === null || mod === undefined) {
             throw new Error(`ImportError: Could not find module ${path}`);
         }
-        if (mod.error != null) {
+        if (mod.error !== null && mod.error !== undefined) {
             throw new Error(`ImportError: Error in module ${path}: ${mod.error}`);
         }
         for (let arg of symbols) {

--- a/src/language/interpreter/interpreter.ts
+++ b/src/language/interpreter/interpreter.ts
@@ -2,7 +2,7 @@ import { gctx } from "src/context";
 import { setPanelContent } from "src/editor/editor";
 import { parser } from "src/language/grammar/otl_parser";
 import { TVisitorBase, Visitors } from "src/language/visitors";
-import { FileSpec, Module, ModuleManagerSync } from "src/utilities/module_manager_sync";
+import { FileSpec, LoadedModule, Module, ModuleManagerSync } from "src/utilities/module_manager_sync";
 
 export class Interpreter extends ModuleManagerSync {
     extensions = ["otl"];
@@ -18,7 +18,7 @@ export class Interpreter extends ModuleManagerSync {
         return visitor.run(node, { interpreter: this, input: code });
     }
 
-    public evaluateModule(file: FileSpec, mod: Module): boolean {
+    public evaluateModule(file: FileSpec, mod: Module): mod is LoadedModule {
         if (file.source === null || file.source === undefined) {
             setPanelContent(`Importing ${this.activeModule?.file.path} failed...`);
             return false;
@@ -33,7 +33,7 @@ export class Interpreter extends ModuleManagerSync {
         }
         let types = Visitors.File.run(tree.topNode, { interpreter: this });
 
-        if (types == null) {
+        if (types === null) {
             setPanelContent(`Importing ${this.activeModule?.file.path} failed...`);
             return false;
         }
@@ -43,7 +43,7 @@ export class Interpreter extends ModuleManagerSync {
     }
 
     protected onAfterImport(fileName: string): void {
-        if (fileName == gctx.plugin.settings.schemaPath) {
+        if (fileName === gctx.plugin.settings.schemaPath) {
             gctx.graph.clear();
             let mainModule = this.modules[fileName];
             for (let key in mainModule.env) {

--- a/src/language/visitors/composite/tagged_string.ts
+++ b/src/language/visitors/composite/tagged_string.ts
@@ -1,6 +1,6 @@
 import { snippetCompletion } from "@codemirror/autocomplete";
 import { gctx } from "src/context";
-import { ExprScript, FnScript } from "src/scripting";
+import { ExprScript, FnScript, TranspilationError } from "src/scripting";
 import { Values } from "src/typing";
 import { dedent } from "src/utilities/dedent";
 import * as Visitors from ".";

--- a/src/scripting/function_script.ts
+++ b/src/scripting/function_script.ts
@@ -4,7 +4,7 @@ import { Note } from "src/typing";
 import { DataClass, field } from "src/utilities";
 import { compileFunctionWithContext } from "./transpilation";
 
-interface IScriptContextBase {
+export interface IScriptContextBase {
     note?: Note;
     _import_explicit?: typeof gctx.api._import_explicit;
 }

--- a/src/scripting/import_manager.ts
+++ b/src/scripting/import_manager.ts
@@ -1,12 +1,12 @@
 import { Fragment, h } from "preact";
 import { gctx } from "src/context";
-import { FileSpec, Module, ModuleManagerSync } from "src/utilities/module_manager_sync";
+import { FileSpec, LoadedModule, Module, ModuleManagerSync } from "src/utilities/module_manager_sync";
 import { compileModuleWithContext } from "./transpilation";
 
 export class ImportManager extends ModuleManagerSync {
     extensions = ["tsx", "ts", "jsx", "js"];
 
-    protected evaluateModule(file: FileSpec, mod: Module): boolean {
+    protected evaluateModule(file: FileSpec, mod: Module): mod is LoadedModule {
         try {
             mod.env = compileModuleWithContext(
                 file.source,

--- a/src/scripting/index.ts
+++ b/src/scripting/index.ts
@@ -1,3 +1,3 @@
-export { ExprScript, FnScript, Script } from "./function_script";
+export { ExprScript, FnScript, Script, IScriptContextBase } from "./function_script";
 export { ImportManager } from "./import_manager";
-export { compileFunctionWithContext, compileModuleWithContext } from "./transpilation";
+export { compileFunctionWithContext, compileModuleWithContext, TranspilationError, TranspilationResult } from "./transpilation";

--- a/src/scripting/transform.tsx
+++ b/src/scripting/transform.tsx
@@ -1,9 +1,50 @@
+import { NodePath, PluginObj } from "@babel/core";
+import {
+    ArrayExpression,
+    CallExpression,
+    ExportAllDeclaration,
+    ExportNamedDeclaration,
+    ExportSpecifier,
+    Identifier,
+    ImportDeclaration,
+    ImportSpecifier,
+    Node,
+    ObjectProperty,
+    StringLiteral,
+    VariableDeclaration
+} from "@babel/types";
+
 interface TranspilationOptions {
     ctxObject: string;
     importFunction: string;
 }
 
-function buildImportArgs(path) {
+declare module "@babel/types" {
+    interface ExportSpecifier {
+        imported?: undefined;
+    }
+    interface ExportDefaultSpecifier {
+        local?: undefined;
+    }
+    interface ExportNamespaceSpecifier {
+        local?: undefined;
+    }
+    interface ImportSpecifier {
+        exported?: undefined;
+    }
+}
+
+function getText(expr: StringLiteral | Identifier): string {
+    return expr.type === "StringLiteral" ? expr.value : expr.name;
+}
+
+function getExternalName(specifier: ImportSpecifier | ExportSpecifier): string {
+    return getText(specifier.type === "ImportSpecifier" ? specifier.imported : specifier.exported);
+}
+
+function buildImportArgs(
+    path: NodePath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>
+): [StringLiteral, ArrayExpression] {
     if (path.node.type === "ExportAllDeclaration") {
         return [
             { type: "StringLiteral", value: path.node.source.value },
@@ -19,7 +60,7 @@ function buildImportArgs(path) {
                 if (specifier.type === "ImportSpecifier" || specifier.type === "ExportSpecifier") {
                     return {
                         type: "StringLiteral",
-                        value: specifier.imported ? specifier.imported.name : specifier.exported.name,
+                        value: getExternalName(specifier),
                     };
                 } else if (specifier.type === "ImportDefaultSpecifier" || specifier.type === "ExportDefaultSpecifier") {
                     return { type: "StringLiteral", value: "default" };
@@ -34,58 +75,65 @@ function buildImportArgs(path) {
     ];
 }
 
-function buildDeclarations(path, importArgs, isExport, exportAllAs, options: TranspilationOptions) {
-    const importCall = {
+function buildDeclarations(
+    path: NodePath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>,
+    importArgs: [StringLiteral, ArrayExpression],
+    isExport: boolean,
+    exportAllAs: string | undefined,
+    options: TranspilationOptions
+): Node {
+    const importCall: CallExpression = {
         type: "CallExpression",
         callee: {
             type: "MemberExpression",
             object: { type: "Identifier", name: options.ctxObject },
             property: { type: "Identifier", name: options.importFunction },
+            computed: false,
         },
         arguments: importArgs,
     };
 
-    const properties =
+    const properties: ObjectProperty[] =
         path.node.type === "ExportAllDeclaration"
             ? [
-                  {
-                      type: "ObjectProperty",
-                      key: { type: "Identifier", name: "__star__" },
-                      value: { type: "Identifier", name: exportAllAs },
-                      computed: false,
-                      shorthand: false,
-                  },
-              ]
+                {
+                    type: "ObjectProperty",
+                    key: { type: "Identifier", name: "__star__" },
+                    value: { type: "Identifier", name: exportAllAs },
+                    computed: false,
+                    shorthand: false,
+                },
+            ]
             : path.node.specifiers.map((specifier) => {
-                  let importedName;
-                  let localName;
-                  if (specifier.type === "ImportSpecifier" || specifier.type === "ExportSpecifier") {
-                      importedName = specifier.imported ? specifier.imported.name : specifier.exported.name;
-                      localName = isExport && specifier.exported ? specifier.exported.name : specifier.local.name;
-                  } else if (
-                      specifier.type === "ImportDefaultSpecifier" ||
-                      specifier.type === "ExportDefaultSpecifier"
-                  ) {
-                      importedName = "default";
-                      localName = specifier.local.name;
-                  } else if (
-                      specifier.type === "ImportNamespaceSpecifier" ||
-                      specifier.type === "ExportNamespaceSpecifier"
-                  ) {
-                      importedName = "__star__";
-                      localName = specifier.local.name;
-                  }
+                let importedName;
+                let localName;
+                if (specifier.type === "ImportSpecifier" || specifier.type === "ExportSpecifier") {
+                    importedName = getExternalName(specifier);
+                    localName = isExport && specifier.exported ? getText(specifier.exported) : specifier.local.name;
+                } else if (
+                    specifier.type === "ImportDefaultSpecifier" ||
+                    specifier.type === "ExportDefaultSpecifier"
+                ) {
+                    importedName = "default";
+                    localName = specifier.local.name;
+                } else if (
+                    specifier.type === "ImportNamespaceSpecifier" ||
+                    specifier.type === "ExportNamespaceSpecifier"
+                ) {
+                    importedName = "__star__";
+                    localName = specifier.local.name;
+                }
 
-                  return {
-                      type: "ObjectProperty",
-                      key: { type: "Identifier", name: importedName },
-                      value: { type: "Identifier", name: localName },
-                      computed: false,
-                      shorthand: importedName === localName,
-                  };
-              });
+                return {
+                    type: "ObjectProperty",
+                    key: { type: "Identifier", name: importedName },
+                    value: { type: "Identifier", name: localName },
+                    computed: false,
+                    shorthand: importedName === localName,
+                };
+            });
 
-    const declarations = {
+    const declarations: VariableDeclaration = {
         type: "VariableDeclaration",
         declarations: [
             {
@@ -102,13 +150,14 @@ function buildDeclarations(path, importArgs, isExport, exportAllAs, options: Tra
 
     return isExport
         ? {
-              type: "ExportNamedDeclaration",
-              declaration: declarations,
-          }
+            type: "ExportNamedDeclaration",
+            declaration: declarations,
+            specifiers: [],
+        }
         : declarations;
 }
 
-export const customImportExportTransform = (options: TranspilationOptions) => {
+export const customImportExportTransform = (options: TranspilationOptions): PluginObj => {
     return {
         visitor: {
             ImportDeclaration(path) {
@@ -122,13 +171,18 @@ export const customImportExportTransform = (options: TranspilationOptions) => {
                 // If it's not, no need to transform it, it's a simple export
             },
             ExportAllDeclaration(path) {
-                transformImportDeclaration(path, true, path.node.exported.name, options);
+                transformImportDeclaration(path, true, getText(path.node.exported), options);
             },
         },
     };
 };
 
-function transformImportDeclaration(path, isExport, exportAllAs, options: TranspilationOptions) {
+function transformImportDeclaration(
+    path: NodePath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>,
+    isExport: boolean,
+    exportAllAs: string | undefined,
+    options: TranspilationOptions
+): void {
     const importArgs = buildImportArgs(path);
     const declarations = buildDeclarations(path, importArgs, isExport, exportAllAs, options);
     path.replaceWith(declarations);

--- a/src/scripting/transpilation.ts
+++ b/src/scripting/transpilation.ts
@@ -1,22 +1,23 @@
+import { PluginItem, PluginObj, TransformOptions } from "@babel/core";
 import { availablePlugins, transform } from "@babel/standalone";
 import { customImportExportTransform } from "./transform";
 
 const transformReactJSX = availablePlugins["transform-react-jsx"];
 const transformModulesCommonJS = availablePlugins["transform-modules-commonjs"];
 
-interface TranspilationError {
+export interface TranspilationError {
     message: string;
     stack?: string;
 }
 
-type TranspilationResult = {
+export type TranspilationResult = {
     code?: string;
     errors?: Array<TranspilationError>;
 };
 
-const removeUseStrict = {
+const removeUseStrict: PluginObj = {
     visitor: {
-        Directive(path: any) {
+        Directive(path) {
             if (path.node.value.value === "use strict") {
                 path.remove();
             }
@@ -24,19 +25,19 @@ const removeUseStrict = {
     },
 };
 
-const DEFAULT_PLUGINS = [
+const DEFAULT_PLUGINS: PluginItem[] = [
     [transformReactJSX, { pragma: "h", pragmaFrag: "Fragment" }],
     transformModulesCommonJS,
     removeUseStrict,
 ];
 
-const DEFAULT_PARSER_OPTS = {
+const DEFAULT_PARSER_OPTS: TransformOptions["parserOpts"] = {
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
     // allowAwaitOutsideFunction: true, TODO: do we need it?
 };
 
-const DEFAULT_TRANSPILE_OPTIONS = {
+const DEFAULT_TRANSPILE_OPTIONS: TransformOptions = {
     plugins: [
         customImportExportTransform({ ctxObject: "api", importFunction: "_import_explicit" }),
         ...DEFAULT_PLUGINS,
@@ -45,9 +46,9 @@ const DEFAULT_TRANSPILE_OPTIONS = {
     filename: "file.tsx",
 };
 
-const MODULE_TRANSPILE_OPTIONS = DEFAULT_TRANSPILE_OPTIONS;
+const MODULE_TRANSPILE_OPTIONS: TransformOptions = DEFAULT_TRANSPILE_OPTIONS;
 
-const FUNCTION_TRANSPILE_OPTIONS = {
+const FUNCTION_TRANSPILE_OPTIONS: TransformOptions = {
     plugins: [
         customImportExportTransform({ ctxObject: "__ctx", importFunction: "_import_explicit" }),
         ...DEFAULT_PLUGINS,
@@ -56,7 +57,7 @@ const FUNCTION_TRANSPILE_OPTIONS = {
     filename: "file.tsx",
 };
 
-export function transpile(source: string, options = DEFAULT_TRANSPILE_OPTIONS): TranspilationResult {
+export function transpile(source: string, options: TransformOptions = DEFAULT_TRANSPILE_OPTIONS): TranspilationResult {
     try {
         let result = transform(source, options);
         return { code: result.code };
@@ -114,7 +115,7 @@ export function compileFunctionWithContext(
     context: Record<string, any> = {},
     args: string[] = ["ctx", "note"],
     options: { transpile: boolean } = { transpile: true }
-): Function | TranspilationError {
+): (Function & { message?: undefined }) | TranspilationError {
     if (options.transpile) {
         let transpiled = transpileFunction(code);
         if (transpiled.errors) {

--- a/src/typing/style.ts
+++ b/src/typing/style.ts
@@ -14,9 +14,15 @@ export enum HideInlineFieldsValues {
     DEFINED = "defined",
 }
 
+export interface ILinkScriptContext extends IScriptContextBase {
+    container?: HTMLElement;
+    linkText?: string;
+    props?: {};
+}
+
 export class Style extends DataClass {
     @field()
-    public link?: FnScript | null = null;
+    public link?: FnScript<ILinkScriptContext> | null = null;
     @field()
     public header?: FnScript | Values.Markdown | null = null;
     @field()

--- a/src/utilities/module_manager_sync.ts
+++ b/src/utilities/module_manager_sync.ts
@@ -30,7 +30,6 @@ export abstract class ModuleManagerSync<ContextType = any> {
     protected modules: Record<string, Module>;
     protected files: Record<string, FileSpec>;
     protected dependencyGraph: DependencyGraph;
-    protected context: ContextType;
     protected callStack: StackFrame[] = [];
 
     public readonly extensions: string[] = [];

--- a/src/utilities/module_manager_sync.ts
+++ b/src/utilities/module_manager_sync.ts
@@ -2,11 +2,19 @@ import { Plugin, TFile, Vault } from "obsidian";
 import { dirname, join, normalize } from "path-browserify";
 import { DependencyGraph } from "src/utilities/dependency_graph";
 
-export interface Module {
+export type FailedModule = {
+    error: string;
+    env?: Record<string, any>;
+    file?: FileSpec;
+};
+
+export type LoadedModule = {
+    error?: undefined;
     env: Record<string, any>;
     file: FileSpec;
-    error?: string;
-}
+};
+
+export type Module = FailedModule | LoadedModule;
 
 export interface FileSpec {
     source: string;
@@ -86,7 +94,9 @@ export abstract class ModuleManagerSync<ContextType = any> {
             return { error: `Unknown file: ${path}` };
         }
 
-        const module: Module = { env: {}, file };
+        // The expression below is used to make the TypeScript compiler
+        // "forget" the const values and fix type inference.
+        const module: Module = ((x: Module) => x)({ env: {}, file })
 
         this.enterFrame({ module });
 
@@ -176,7 +186,7 @@ export abstract class ModuleManagerSync<ContextType = any> {
         }
     }
 
-    protected abstract evaluateModule(file: FileSpec, env: Module): boolean;
+    protected abstract evaluateModule(file: FileSpec, mod: Module): mod is LoadedModule;
 
     protected async loadFile(path: string): Promise<string> {
         let tfile = this.vault.getAbstractFileByPath(path);
@@ -239,10 +249,10 @@ export abstract class ModuleManagerSync<ContextType = any> {
         return this.extensions.some((ext) => path.endsWith("." + ext));
     }
 
-    protected onAfterPreload(): void {}
-    protected onModuleUpdate(path: string): void {}
-    protected onBeforeImport(path: string): void {}
-    protected onAfterImport(path: string): void {}
-    protected onBeforeReload(path: string): void {}
-    protected onAfterReload(path: string): void {}
+    protected onAfterPreload(): void { }
+    protected onModuleUpdate(path: string): void { }
+    protected onBeforeImport(path: string): void { }
+    protected onAfterImport(path: string): void { }
+    protected onBeforeReload(path: string): void { }
+    protected onAfterReload(path: string): void { }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,6 @@
 import "obsidian";
 import { DataviewApi } from "obsidian-dataview";
+import { Identifier, StringLiteral } from "@babel/types";
 
 declare module "obsidian" {
     interface App {
@@ -30,5 +31,14 @@ declare module "obsidian" {
     }
     interface MarkdownPostProcessorContext {
         containerEl?: HTMLElement;
+    }
+}
+
+declare module "@babel/types" {
+    interface ExportAllDeclaration {
+        // The type declaration for @babel/types do not match what is generated when
+        // parsing `export * as A from "source"`, as evidenced by babel's own tests:
+        // https://github.com/babel/babel/blob/64fa46676b5729fcc53fbc71ccd4615d3017fe08/packages/babel-parser/test/fixtures/estree/export/ns-from/output.json
+        exported?: StringLiteral | Identifier;
     }
 }


### PR DESCRIPTION
This is part of the effort (see cr7pt0gr4ph7/obsidian-typing#10) of getting this plugin to successfully typecheck using `tsc` without errors.