### PR TITLE
types: Improve typing of `src/utils/*` and a few other utilities

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -30,7 +30,7 @@ export const scssTypesPlugin = (stylesPattern, watch) => {
             console.log("setup", stylesPattern);
             build.onStart(async () => {
                 console.log("onstart");
-                await generateScssTypeDeclarations(stylesPattern);
+                await generateScssTypeDeclarations(stylesPattern, {  });
                 setupDone = true;
             });
 

--- a/src/language/visitors/composite/import.ts
+++ b/src/language/visitors/composite/import.ts
@@ -3,7 +3,7 @@ import { Type } from "src/typing";
 import { createVisitor, Rules } from "../index_base";
 import * as Visitors from "../pure";
 
-interface ImportSymbol {
+export interface ImportSymbol {
     symbol?: string;
     alias?: string;
     node: SyntaxNode;

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -58,7 +58,7 @@ interface StackFrame {
     call: InternalCallType;
 }
 
-interface GlobalCallContext {
+export interface GlobalCallContext {
     input?: string;
     doc?: Text;
     state?: EditorState;

--- a/src/language/visitors/wrappers/index.ts
+++ b/src/language/visitors/wrappers/index.ts
@@ -1,2 +1,1 @@
-export * from "../index_base";
 export { ScopeWrapper } from "./scope";

--- a/src/language/visitors/wrappers/scope.ts
+++ b/src/language/visitors/wrappers/scope.ts
@@ -1,4 +1,4 @@
-import { NodeType, Rules, Symbol, TVisitorArgsBase } from ".";
+import { NodeType, Rules, Symbol, TVisitorArgsBase } from "..";
 
 export const ScopeWrapper = ({ shouldComplete = true }: { shouldComplete: boolean }) => {
     return {

--- a/src/utilities/date_parsing.ts
+++ b/src/utilities/date_parsing.ts
@@ -11,9 +11,9 @@ custom.parsers.splice(
         },
         extract: (context, match) => {
             let result = {
-                month: +match.groups["month"],
-                day: +(match.groups["day"] ?? context.refDate.getDay()),
-                year: +(match.groups["year"] ?? context.refDate.getFullYear()),
+                month: +match.groups!["month"],
+                day: +(match.groups!["day"] ?? context.refDate.getDay()),
+                year: +(match.groups!["year"] ?? context.refDate.getFullYear()),
             };
             return result;
         },
@@ -24,9 +24,9 @@ custom.parsers.splice(
         },
         extract: (context, match) => {
             let result = {
-                day: +match.groups["day"],
-                month: +(match.groups["month"] ?? context.refDate.getMonth()),
-                year: +(match.groups["year"] ?? context.refDate.getFullYear()),
+                day: +match.groups!["day"],
+                month: +(match.groups!["month"] ?? context.refDate.getMonth()),
+                year: +(match.groups!["year"] ?? context.refDate.getFullYear()),
             };
             return result;
         },
@@ -37,9 +37,9 @@ custom.parsers.splice(
         },
         extract: (context, match) => {
             let result = {
-                year: +match.groups["year"],
-                month: +(match.groups["month"] ?? context.refDate.getMonth()),
-                day: +(match.groups["day"] ?? context.refDate.getDay()),
+                year: +match.groups!["year"],
+                month: +(match.groups!["month"] ?? context.refDate.getMonth()),
+                day: +(match.groups!["day"] ?? context.refDate.getDay()),
             };
             return result;
         },

--- a/src/utilities/link_rendering.tsx
+++ b/src/utilities/link_rendering.tsx
@@ -51,9 +51,9 @@ export const RenderLink = ({
     linkText,
     ...props
 }: {
-    type: Type;
+    type?: Type | null;
     note: Note;
-    container?: HTMLElement;
+    container?: HTMLElement | null;
     linkText?: string;
 }) => {
     if (!type) {
@@ -63,7 +63,7 @@ export const RenderLink = ({
     let linkScript = type.style?.link;
     if (linkScript) {
         try {
-            let el = linkScript.call({ note, container, linkText, props });
+            let el = linkScript.call({ note, container: container ?? undefined, linkText, props });
             if (el) {
                 return el;
             }

--- a/src/utilities/logger.ts
+++ b/src/utilities/logger.ts
@@ -145,6 +145,7 @@ function safeStringify(obj: any, depth: number = 1): string {
         },
         2
     );
+    // @ts-ignore
     cache = null; // Enable garbage collection
     return stringify;
 }

--- a/src/utilities/misc.ts
+++ b/src/utilities/misc.ts
@@ -1,18 +1,19 @@
-function isObject(item: any): item is Object {
+function isObject(item: any): item is object {
     return item && typeof item === "object" && !Array.isArray(item);
 }
 
-export function mergeDeep(target: any, source: any) {
-    let output = Object.assign({}, target);
+export function mergeDeep<T, S>(target: T, source: S): T & S & {} {
+    let output: T & S = Object.assign({}, target) as any;
     if (isObject(target) && isObject(source)) {
-        Object.keys(source).forEach((key) => {
+        Object.keys(source).forEach((k) => {
+            let key: keyof S & keyof T & string = k as any;
             if (isObject(source[key])) {
-                if (!(key in target)) Object.assign(output, { [key]: source[key] });
-                else output[key] = mergeDeep(target[key], source[key]);
+                if (!(key in target)) Object.assign(output!, { [key]: source[key] });
+                else output[key] = mergeDeep(target[key] as any, source[key] as any) as any;
             } else {
-                Object.assign(output, { [key]: source[key] });
+                Object.assign(output!, { [key]: source[key] });
             }
         });
     }
-    return output;
+    return output as T & S & {};
 }


### PR DESCRIPTION
This is part of the general effort (see cr7pt0gr4ph7/obsidian-typing#10) of improving the type checking for the code of this plugin.

All usages of the definite assignment operator (i.e. <code><em>&lt;expr&gt;</em>!</code>) have been verified to be safe.