### PR TITLE
types: Improve type inference around `Visitor` creation

### DIFF
--- a/src/language/visitors/composite/attribute.ts
+++ b/src/language/visitors/composite/attribute.ts
@@ -2,14 +2,14 @@ import { snippet, startCompletion } from "@codemirror/autocomplete";
 import * as Visitors from ".";
 import { createVisitor, Rules, TVisitorBase } from "../index_base";
 
-export const NamedAttribute = (valueType: TVisitorBase) =>
+export const NamedAttribute = <V extends TVisitorBase>(valueType: V) =>
     createVisitor({
         rules: Rules.Assignment,
         children: {
             name: Visitors.Proxy(Rules.AssignmentName, Visitors.Identifier()),
             value: createVisitor({
                 rules: Rules.AssignmentValue,
-                run() {
+                run(): ReturnType<V["run"]> | undefined {
                     return this.runChildren({ keys: ["literal"], eager: true })["literal"];
                 },
                 children: { literal: Visitors.Literal(valueType) },
@@ -43,7 +43,7 @@ export const NamedAttribute = (valueType: TVisitorBase) =>
         },
     });
 
-export const Attribute = (name: string, valueType: TVisitorBase, info?: string) =>
+export const Attribute = <N extends string, V extends TVisitorBase>(name: N, valueType: V, info?: string) =>
     NamedAttribute(valueType).extend({
         accept(node) {
             if (name == null) return true;
@@ -51,7 +51,7 @@ export const Attribute = (name: string, valueType: TVisitorBase, info?: string) 
             if (!nameNode) return false;
             return this.children.name.run(nameNode) == name;
         },
-        run() {
+        run(): ReturnType<V["run"]> | undefined {
             return this.runChildren({ keys: ["value"], eager: true })["value"];
         },
         snippets() {

--- a/src/language/visitors/composite/field.ts
+++ b/src/language/visitors/composite/field.ts
@@ -183,7 +183,15 @@ export const Field = () =>
             return FieldObject.new({
                 name: name ?? undefined,
                 type: type ?? undefined,
-                default: defaultValue ?? undefined,
+                // TODO: We temporarily cheat the compiler here:
+                //
+                //       While defaultValue might have a non-string type,
+                //       the constructor will turn it into a string value
+                //       using type.parseDefault anyway.
+                //
+                //       We will have to revisit this in the future once we
+                //       add better support for composite values (arrays, objects).
+                default: defaultValue as string ?? undefined,
                 ...opts
             });
         },

--- a/src/language/visitors/composite/list.ts
+++ b/src/language/visitors/composite/list.ts
@@ -3,7 +3,7 @@ import { SyntaxNode } from "@lezer/common";
 import * as Visitors from ".";
 import { createVisitor, Rules, TVisitorBase } from "../index_base";
 
-export const List = (valueType: TVisitorBase, opts?: { info?: string }) =>
+export const List = <V extends TVisitorBase>(valueType: V, opts?: { info?: string }) =>
     createVisitor({
         rules: Rules.List,
         children: {
@@ -13,7 +13,7 @@ export const List = (valueType: TVisitorBase, opts?: { info?: string }) =>
             return valueType.snippets();
         },
         run() {
-            let result: ReturnType<(typeof valueType)["run"]>[] = [];
+            let result: ReturnType<V["run"]>[] = [];
             let unexpectedNodes: SyntaxNode[] = [];
             this.traverse(
                 (node, child) => {

--- a/src/language/visitors/pure/literal.ts
+++ b/src/language/visitors/pure/literal.ts
@@ -41,10 +41,13 @@ export const Boolean = createVisitor({
     },
 });
 
-export const LiteralString = (values: string[]) =>
+export const LiteralString = <const A extends T[], const T extends string = A extends (infer TT)[] ? TT : never>(values: A) =>
     String.override({
+        run(node) {
+            return this.super.run(node) as T;
+        },
         lint(node) {
-            if (!values.contains(stripQuotes(this.getNodeText(node)))) {
+            if (!values.contains(stripQuotes(this.getNodeText(node)) as T)) {
                 this.error(`Allowed values: ${values}`);
             }
         },
@@ -53,7 +56,7 @@ export const LiteralString = (values: string[]) =>
         },
     });
 
-export const Literal = (type: TVisitorBase) =>
+export const Literal = <V extends TVisitorBase>(type: V) =>
     createVisitor({
         rules: Rules.Literal,
         children: { type },

--- a/src/language/visitors/pure/proxy.ts
+++ b/src/language/visitors/pure/proxy.ts
@@ -1,23 +1,21 @@
 import { createVisitor, Rules, TUtilsBase, TVisitorBase, Visitor } from "../index_base";
 
 export const Proxy = <V extends TVisitorBase>(proxyRules: Rules | Rules[], visitor: V):
-    Visitor<ReturnType<V["run"]>, {
-        visitor: V;
-    }, TUtilsBase, unknown, TVisitorBase<any, any, any, any>> =>
+    Visitor<ReturnType<V["run"]>, { visitor: V; }, TUtilsBase, unknown, TVisitorBase<any, any, any, any>> =>
     createVisitor({
         rules: proxyRules,
         children: { visitor },
         accept(node) {
-            return visitor.accept(node?.firstChild!);
+            return visitor.accept(node.firstChild!);
         },
         run(node) {
-            return visitor.run(node?.firstChild!) as ReturnType<V["run"]>;
+            return visitor.run(node.firstChild!) as ReturnType<V["run"]>;
         },
         lint(node) {
-            return visitor.lint(node?.firstChild!);
+            return visitor.lint(node.firstChild!);
         },
         complete(node, context) {
-            return visitor.complete(node?.firstChild!, context);
+            return visitor.complete(node.firstChild!, context);
         },
         snippets() {
             return visitor.snippets();

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -40,7 +40,27 @@ export interface Symbol {
     metadata?: any;
 }
 
-type AnyVisitor = Visitor<any, any, any, any, any>;
+export type VisitorTypes<
+    Return = any,
+    Children = any,
+    Utils = any,
+    Cache = any,
+    Super = any
+> = {
+    Return?: Return,
+    Children?: Children,
+    Utils?: Utils,
+    Cache?: Cache,
+    Super?: Super
+};
+
+export type AnyVisitor<Args extends VisitorTypes = {}> = Visitor<
+    OneOf<VisitorTypes["Return"], Args["Return"]>,
+    OneOf<VisitorTypes["Children"], Args["Children"]>,
+    OneOf<VisitorTypes["Utils"], Args["Utils"]>,
+    OneOf<VisitorTypes["Cache"], Args["Cache"]>,
+    OneOf<VisitorTypes["Super"], Args["Super"]>
+>;
 
 let cache: NodeWeakMap<WeakMap<AnyVisitor, CacheEntry>>;
 

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -257,12 +257,23 @@ export class Visitor<
             OneOf<Utils, Utils2>,
             OneOf<CacheType, CacheType2>,
             NewSuper
+        >,
+        Args extends VisitorArgs<
+            Return2,
+            Children2,
+            Utils2,
+            CacheType2,
+            NewThis
+        > = VisitorArgs<
+            Return2,
+            Children2,
+            Utils2,
+            CacheType2,
+            NewThis
         >
-    >(
-        args: VisitorArgs<Return2, Children2, Utils2, CacheType2, NewThis>
-    ): Visitor<Return2, Children2, Utils2, CacheType2, NewSuper> {
+    >(args: Args): Visitor<ReturnType<Args["run"]>, Children2, Utils2, CacheType2, NewSuper> {
         let newArgs = Object.assign({}, this.originalArgs, args);
-        let result = Visitor.fromArgs<Return2, Children2, Utils2, CacheType2, NewSuper>(newArgs as any);
+        let result = Visitor.fromArgs<ReturnType<Args["run"]>, Children2, Utils2, CacheType2, NewSuper>(newArgs as any);
         result.super = Visitor.fromArgs<Return, Children, Utils, CacheType, Super>(this.originalArgs as any) as NewSuper;
         result.super.derived = result;
         result.super.bind(result);

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -10,8 +10,31 @@ import { Interpreter } from "../interpreter";
 
 export type NodeType = SyntaxNode;
 
-type Merge<A, B> = B extends void ? A : A extends void ? B : A & B;
-type OneOf<A, B> = B extends void ? A : B;
+type Merge<A, B> = unknown extends B ? A : unknown extends A ? B : A & B;
+type OneOf<A, B> = unknown extends B ? A : B;
+
+// Static tests of OneOf and Merge
+namespace StaticTests {
+    type SameType<A, B> = A | B extends A & B ? true : false;
+
+    true satisfies SameType<string, string>;
+    true satisfies SameType<unknown, unknown>;
+    false satisfies SameType<string, number>;
+    false satisfies SameType<unknown, string>;
+    false satisfies SameType<string, unknown>;
+
+    true satisfies SameType<Merge<string, number>, string & number>;
+    true satisfies SameType<Merge<number, string>, string & number>;
+    true satisfies SameType<Merge<unknown, string>, string>;
+    true satisfies SameType<Merge<string, unknown>, string>;
+    true satisfies SameType<Merge<unknown, unknown>, unknown>;
+
+    true satisfies SameType<OneOf<string, number>, number>;
+    true satisfies SameType<OneOf<number, string>, string>;
+    true satisfies SameType<OneOf<unknown, string>, string>;
+    true satisfies SameType<OneOf<string, unknown>, string>;
+    true satisfies SameType<OneOf<unknown, unknown>, unknown>;
+}
 
 interface CompletionEntry extends Completion {
     symbol?: string;

--- a/src/language/visitors/visitor.ts
+++ b/src/language/visitors/visitor.ts
@@ -224,8 +224,8 @@ export class Visitor<
         >
     >(
         args: VisitorArgs<Return2, Children2, Utils2, CacheType2, Super, This>
-    ): Visitor<Return2, Children2, Utils2, CacheType2, Super> {
-        return Visitor.new<Visitor<Return2, Children2, Utils2, CacheType2, Super>>({
+    ): Visitor<OneOf<null, Return2>, Children2, Utils2, CacheType2, Super> {
+        return Visitor.new<Visitor<OneOf<null, Return2>, Children2, Utils2, CacheType2, Super>>({
             // Ignore the fact that `This` might be different type
             // than the one specified in the type parameter default
             args: args as any,
@@ -258,7 +258,9 @@ export class Visitor<
             OneOf<CacheType, CacheType2>,
             NewSuper
         >
-    >(args: VisitorArgs<Return2, Children2, Utils2, CacheType2, NewThis>) {
+    >(
+        args: VisitorArgs<Return2, Children2, Utils2, CacheType2, NewThis>
+    ): Visitor<Return2, Children2, Utils2, CacheType2, NewSuper> {
         let newArgs = Object.assign({}, this.originalArgs, args);
         let result = Visitor.fromArgs<Return2, Children2, Utils2, CacheType2, NewSuper>(newArgs as any);
         result.super = Visitor.fromArgs<Return, Children, Utils, CacheType, Super>(this.originalArgs as any) as NewSuper;

--- a/src/typing/field_type/file.tsx
+++ b/src/typing/field_type/file.tsx
@@ -106,7 +106,7 @@ export class File extends FieldType<File> {
                 short: Visitors.Literal(Visitors.Boolean),
             },
             init(args, kwargs) {
-                if (kwargs.ext != null) {
+                if (kwargs.ext !== null && kwargs.ext !== undefined) {
                     if (!Array.isArray(kwargs.ext)) {
                         kwargs.ext = [kwargs.ext];
                     }
@@ -116,7 +116,7 @@ export class File extends FieldType<File> {
                         return x;
                     });
                 }
-                return File.new(kwargs);
+                return File.new(kwargs as (typeof kwargs) & { ext?: string[] });
             },
         });
 }

--- a/src/typing/style.ts
+++ b/src/typing/style.ts
@@ -28,9 +28,9 @@ export class Style extends DataClass {
     @field()
     public footer?: FnScript | Values.Markdown | null = null;
     @field()
-    public show_prefix: ShowPrefixValues = ShowPrefixValues.SMART;
+    public show_prefix: ShowPrefixValues | `${ShowPrefixValues}` = ShowPrefixValues.SMART;
     @field()
-    public hide_inline_fields: HideInlineFieldsValues | null = null;
+    public hide_inline_fields: HideInlineFieldsValues | `${HideInlineFieldsValues}` | null = null;
     @field()
     public css_classes: Array<string> | null = null;
     @field()


### PR DESCRIPTION
This is part of the general effort (see cr7pt0gr4ph7/obsidian-typing#10) of improving the type checking for the code of this plugin.