### PR TITLE
types: Add nullability workarounds in multiple places

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -8,20 +8,20 @@ import { TypingAPI } from "./api";
 import { CSSManager } from "./utilities";
 
 export class GlobalContext {
-    app: App;
-    plugin: TypingPlugin;
-    importManager: ImportManager;
-    interpreter: Interpreter;
-    cssManager: CSSManager;
-    userDefinedCssManager: CSSManager;
-    noteCache: NoteCache;
+    app!: App;
+    plugin!: TypingPlugin;
+    importManager!: ImportManager;
+    interpreter!: Interpreter;
+    cssManager!: CSSManager;
+    userDefinedCssManager!: CSSManager;
+    noteCache!: NoteCache;
 
     testing: boolean = false;
     platform = Platform;
 
     // TODO: rename to `types` to resolve ambiguity with relations?
-    graph: TypeGraph;
-    relations: RelationsManager;
+    graph!: TypeGraph;
+    relations!: RelationsManager;
 
     get settings() {
         return this.plugin.settings;
@@ -30,9 +30,11 @@ export class GlobalContext {
     get api(): TypingAPI {
         return this.plugin.api;
     }
+
     get dv(): DataviewApi {
         if (this.testing) return {} as DataviewApi;
-        return this.app.plugins.plugins.dataview?.api;
+        // TODO: Throw when dataview is not available
+        return this.app.plugins.plugins.dataview?.api!;
     }
     get currentNote(): Note | null {
         let view = this.app.workspace.getActiveViewOfType(MarkdownView);

--- a/src/language/visitors/composite/import.ts
+++ b/src/language/visitors/composite/import.ts
@@ -80,6 +80,6 @@ export const Import = () =>
         symbols() {
             let symbols = this.runChildren({ keys: ["symbols"] })["symbols"];
             if (!symbols) return null;
-            return symbols.map((x) => ({ nameNode: x.node, node: x.node, name: x.alias }));
+            return symbols.map((x) => ({ nameNode: x.node, node: x.node, name: x.alias! }));
         },
     });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,10 +20,9 @@ import { log } from "src/utilities";
 
 export default class TypingPlugin extends Plugin {
     exports: any;
-    ctx: GlobalContext;
-    api: TypingAPI;
-
-    settings: TypingSettings;
+    ctx!: GlobalContext;
+    api!: TypingAPI;
+    settings!: TypingSettings;
 
     async onload() {
         log.info("Loading plugin");

--- a/src/ui/hooks/blur.tsx
+++ b/src/ui/hooks/blur.tsx
@@ -3,7 +3,7 @@ import { Contexts } from "..";
 
 export function useBlurCallbacks() {
     const promptCtx = useContext(Contexts.PromptContext);
-    const pickerCtx = useContext(Contexts.PickerContext);
+    const pickerCtx = useContext(Contexts.PickerContext)!;
     const dropdownCtx = useContext(Contexts.DropdownContext);
 
     const onPickerBlur = useCallback(

--- a/src/ui/hooks/controls.tsx
+++ b/src/ui/hooks/controls.tsx
@@ -31,7 +31,7 @@ export function useControls<T extends ControlsRecord>({
     compose: (values: T) => string;
     id?: string;
 }): ControlsResult<Omit<T, keyof CompositeControl>> {
-    const pickerCtx = useContext(Contexts.PickerContext);
+    const pickerCtx = useContext(Contexts.PickerContext)!;
     const value = pickerCtx.state.value;
     const [state, setState] = useState<T>(() => parse(value));
 

--- a/src/ui/pickers/checkbox.tsx
+++ b/src/ui/pickers/checkbox.tsx
@@ -5,7 +5,7 @@ import { useControls } from "../hooks";
 import styles from "src/styles/prompt.scss";
 
 export function Checkbox() {
-    const pickerCtx = useContext(Contexts.PickerContext);
+    const pickerCtx = useContext(Contexts.PickerContext)!;
     let inList = useContext(Contexts.ListContext);
     let controls = useControls({
         parse: (text) => {

--- a/src/ui/pickers/file.tsx
+++ b/src/ui/pickers/file.tsx
@@ -74,8 +74,8 @@ export const File = ({
         parse: parseLinkExtended,
         compose,
     });
-    const promptCtx = useContext(Contexts.PromptContext);
-    const pickerCtx = useContext(Contexts.PickerContext);
+    const promptCtx = useContext(Contexts.PromptContext)!;
+    const pickerCtx = useContext(Contexts.PickerContext)!;
 
     const [file, setFile] = useState<File>(null);
 

--- a/src/ui/pickers/list.tsx
+++ b/src/ui/pickers/list.tsx
@@ -14,7 +14,7 @@ export const ListContext = createContext(false);
 const REMOVE_CONST = "<|REMOVE|>";
 
 export function List({ SubPicker }: { SubPicker: any }) {
-    let pickerCtx = useContext(PickerContext);
+    let pickerCtx = useContext(PickerContext)!;
     const refs = useRef<RefObject<HTMLButtonElement>[]>();
 
     let controls = useControls({

--- a/src/ui/pickers/text.tsx
+++ b/src/ui/pickers/text.tsx
@@ -36,7 +36,7 @@ const noNewLineField = StateField.define<null>({
 
 export function Text() {
     let inList = useContext(Contexts.ListContext);
-    let pickerCtx = useContext(Contexts.PickerContext);
+    let pickerCtx = useContext(Contexts.PickerContext)!;
     let controls = useControls({
         parse: (text) => {
             if (inList) {


### PR DESCRIPTION
This is part of the general effort (see cr7pt0gr4ph7/obsidian-typing#10) of improving the type checking for the code of this plugin.

The non-null assertions introduced here should be reviewed (and preferably removed) at a later date.