### PR TITLE
feat: Add `Required[...]` field type

### DIFF
--- a/docs/docs/reference/field-types/required.md
+++ b/docs/docs/reference/field-types/required.md
@@ -1,0 +1,30 @@
+# Required
+
+A generic type: Require the underlying field to be present.
+
+- Requires that the field is present, i.e. declared explicitly in the note.
+- If the underlying field type is a scalar (i.e. anything except [List](./list)):
+  Requires that the field value is not an empty string.
+- If the underlying field type is a [List](./list):
+  Requires that the list contains at least one item.
+
+## Parameters
+
+| Parameter    | Value Type                           | Description      |
+| ------------ | ------------------------------------ | ---------------- |
+| `positional` | [FIELD_TYPE](../language#field-type) | Value field type |
+
+## Examples
+
+```otl
+type A {
+    fields {
+        list_str: Required[String]
+        list_num: Required[List[string]]
+    }
+}
+```
+
+## Picker
+
+@TODO

--- a/src/typing/field_type/index_field_types.ts
+++ b/src/typing/field_type/index_field_types.ts
@@ -6,6 +6,7 @@ export { File } from "./file";
 export { List } from "./list";
 export { Note } from "./note";
 export { Number } from "./number";
+export { Required } from "./required";
 export { String } from "./string";
 export { Tag } from "./tag";
 export { Text } from "./text";

--- a/src/typing/field_type/required.tsx
+++ b/src/typing/field_type/required.tsx
@@ -1,0 +1,57 @@
+import { Visitors } from "src/language";
+import { field } from "src/utilities";
+import { FieldType, FieldTypeBindingContext } from "./base";
+
+export class Required extends FieldType<Required> {
+    name = "Required";
+
+    @field({ required: true })
+    public type!: FieldType;
+
+    Display: FieldType["Display"] = ({ value }) => {
+        const SubDisplay = this.type.Display;
+        return <SubDisplay value={value} />;
+    };
+
+    Picker = () => {
+        const SubPicker = this.type.Picker;
+        return <SubPicker />;
+    };
+
+    get default() {
+        return this.type.default;
+    }
+
+    parseDefault(value: any): string {
+        return this.type.parseDefault(value);
+    }
+
+    bind(context: FieldTypeBindingContext): Required {
+        let result = super.bind(context);
+        // TODO: there may be some troubles with field name, as it will be the same as of outer type
+        // result.type = result.type.bind({ type: context.type });
+        result.type = result.type.bind(context);
+        return result;
+    }
+
+    static ParametersVisitor() {
+        return Visitors.ParametersVisitorFactory({
+            args: Visitors.FieldType(),
+            init(args) {
+                return Required.new({ type: args[0] });
+            },
+        });
+    }
+
+    get isRelation() {
+        return this.type.isRelation;
+    }
+
+    get isList() {
+        return this.type.isList;
+    }
+
+    get underlyingType() {
+        return this.type.underlyingType;
+    }
+}


### PR DESCRIPTION
By default, all metadata fields are considered optional. The `Required[...]` marker type can be used to mark metadata fields as required.

Once validation (see https://github.com/cr7pt0gr4ph7/obsidian-typing/labels/typing%2Fvalidation) is implemented, an error should be emitted when any field marked as required is missing from a `Note`.