### PR TITLE
feat: Implement proper transpilation of TS/TSX files

### DIFF
--- a/__mocks__/__vault__/scripts/hooks-sink.tsx
+++ b/__mocks__/__vault__/scripts/hooks-sink.tsx
@@ -1,7 +1,5 @@
-// @ts-ignore // Transpilation of TS files is not yet supported
-export const hookCalls /*: { hookName: string, ctx: any }[]*/ = [];
+export const hookCalls: { hookName: string, ctx: any }[] = [];
 
-// @ts-ignore // Transpilation of TS files is not yet supported
-export function appendHookCall(hookName /*: string*/, ctx /*: any*/) {
+export function appendHookCall(hookName: string, ctx: any) {
     hookCalls.push({ hookName, ctx });
 }

--- a/src/scripting/transpilation.ts
+++ b/src/scripting/transpilation.ts
@@ -1,7 +1,8 @@
 import { PluginItem, PluginObj, TransformOptions } from "@babel/core";
-import { availablePlugins, transform } from "@babel/standalone";
+import { availablePlugins, availablePresets, transform } from "@babel/standalone";
 import { customImportExportTransform } from "./transform";
 
+const presetTypeScript = availablePresets["typescript"];
 const transformReactJSX = availablePlugins["transform-react-jsx"];
 const transformModulesCommonJS = availablePlugins["transform-modules-commonjs"];
 
@@ -41,6 +42,7 @@ const DEFAULT_PARSER_OPTS: TransformOptions["parserOpts"] = {
 };
 
 const DEFAULT_TRANSPILE_OPTIONS: TransformOptions = {
+    presets: [presetTypeScript],
     plugins: [
         customImportExportTransform({ ctxObject: "api", importFunction: "_import_explicit" }),
         ...DEFAULT_PLUGINS,
@@ -52,6 +54,7 @@ const DEFAULT_TRANSPILE_OPTIONS: TransformOptions = {
 const MODULE_TRANSPILE_OPTIONS: TransformOptions = DEFAULT_TRANSPILE_OPTIONS;
 
 const FUNCTION_TRANSPILE_OPTIONS: TransformOptions = {
+    presets: [presetTypeScript],
     plugins: [
         customImportExportTransform({ ctxObject: "__ctx", importFunction: "_import_explicit" }),
         ...DEFAULT_PLUGINS,

--- a/src/scripting/transpilation.ts
+++ b/src/scripting/transpilation.ts
@@ -77,12 +77,12 @@ export function transpile(source: string, options: TransformOptions = DEFAULT_TR
     }
 }
 
-export function transpileModule(source: string) {
-    return transpile(source, MODULE_TRANSPILE_OPTIONS);
+export function transpileModule(source: string, options: { filename?: string } = {}) {
+    return transpile(source, { ...MODULE_TRANSPILE_OPTIONS, ...options });
 }
 
-export function transpileFunction(source: string) {
-    return transpile(source, FUNCTION_TRANSPILE_OPTIONS);
+export function transpileFunction(source: string, options: { filename?: string } = {}) {
+    return transpile(source, { ...FUNCTION_TRANSPILE_OPTIONS, ...options });
 }
 
 export function compileModuleWithContext(
@@ -91,7 +91,7 @@ export function compileModuleWithContext(
     options: { transpile: boolean; filename?: string } = { transpile: true }
 ): Record<string, any> {
     if (options.transpile) {
-        let transpiled = transpileModule(code);
+        let transpiled = transpileModule(code, { filename: options.filename ?? "file.tsx" });
         if (transpiled.errors != null) {
             throw transpiled.errors[0];
         }
@@ -123,10 +123,10 @@ export function compileFunctionWithContext(
     code: string,
     context: Record<string, any> = {},
     args: string[] = ["ctx", "note"],
-    options: { transpile: boolean } = { transpile: true }
+    options: { transpile: boolean, filename?: string } = { transpile: true }
 ): (Function & { message?: undefined }) | TranspilationError {
     if (options.transpile) {
-        let transpiled = transpileFunction(code);
+        let transpiled = transpileFunction(code, { filename: options.filename ?? "file.tsx" });
         if (transpiled.errors) {
             return transpiled.errors[0];
         }

--- a/src/utilities/module_manager_sync.ts
+++ b/src/utilities/module_manager_sync.ts
@@ -54,11 +54,11 @@ export abstract class ModuleManagerSync<ContextType = any> {
         if (!this.extensions.some((ext) => path.endsWith("." + ext))) {
             for (let ext of this.extensions) {
                 let result = this.importModule(path + "." + ext);
-                if (result != null && !result.error) return result;
+                if (result !== null) return result;
             }
             for (let ext of this.extensions) {
                 let result = this.importModule(path + "/index" + "." + ext);
-                if (result != null && !result.error) return result;
+                if (result !== null) return result;
             }
         }
         return this.importModule(path);
@@ -90,7 +90,7 @@ export abstract class ModuleManagerSync<ContextType = any> {
         }
 
         if (!file) {
-            return { error: `Unknown file: ${path}` };
+            return null;
         }
 
         // The expression below is used to make the TypeScript compiler

--- a/src/utilities/module_manager_sync.ts
+++ b/src/utilities/module_manager_sync.ts
@@ -107,7 +107,7 @@ export abstract class ModuleManagerSync<ContextType = any> {
             success = this.evaluateModule(file, module);
         } catch (e) {
             this.exitFrame();
-            return null;
+            return { error: `Unexpected error: ${e}`};
         }
 
         if (!success) {


### PR DESCRIPTION
The actual transpilation settings should depend on the file extension (`.js`, `.jsx`, `.ts`, `.tsx`). As of now, everything is transpiled as `.tsx`. The follow-up issue for this is:

- #54