### PR TITLE
feat: Add `title`, `description` and `category` to Type

### DIFF
--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -107,6 +107,10 @@ export const Type = createVisitor({
                 return this.runChildren();
             },
             children: {
+                title: Visitors.Attribute("title", Visitors.String),
+                description: Visitors.Attribute("description", Visitors.String),
+                category: Visitors.Attribute("category", Visitors.String),
+
                 folder: Visitors.Attribute("folder", Visitors.String), // will be FolderCompletionString or String(completion=...)
                 // TODO: can be specified only in abstract types
                 // TODO: can be specified one of folder and glob
@@ -130,6 +134,20 @@ export const Type = createVisitor({
                                 side: 1,
                             }).range(valueNode.to),
                         ];
+                    },
+                }),
+                display: Visitors.StructuredSection(
+                    "display",
+                    {
+                        title: Visitors.Attribute("title", Visitors.String),
+                        description: Visitors.Attribute("description", Visitors.String),
+                        category: Visitors.Attribute("category", Visitors.String)
+                    },
+                    "Display section"
+                ).override({
+                    run(node) {
+                        let opts = this.runChild("body");
+                        return opts;
                     },
                 }),
                 style: Visitors.StructuredSection(
@@ -272,6 +290,7 @@ export const Type = createVisitor({
             isAbstract,
             name,
             parentNames,
+            ...body?.display,
             ...body,
         });
         return [type];

--- a/src/typing/type.tsx
+++ b/src/typing/type.tsx
@@ -12,11 +12,24 @@ export class Type extends DataClass {
     @field()
     public name!: string;
 
+    get displayName(): string {
+        return this.title || this.name;
+    }
+
     @field()
     public parentNames: Array<string> = [];
 
     @field({ inherit: false })
     public parents: Array<Type> = [];
+
+    @field({ required: false, inherit: false })
+    public title?: string;
+
+    @field({ required: false, inherit: false })
+    public description?: string;
+
+    @field({ required: false, inherit: false })
+    public category?: string;
 
     @field({ required: false, inherit: false })
     public folder?: string;

--- a/src/ui/modals/suggest.tsx
+++ b/src/ui/modals/suggest.tsx
@@ -46,15 +46,20 @@ export class TypeSuggestModal extends SuggestModal<Type> {
             }
         }
     }
+
+    getTypeTitle(type: Type): string {
+        return type.category ? `${type.category}: ${type.displayName}` : type.displayName;
+    }
+
     renderSuggestion(type: Type, el: HTMLElement) {
-        render(<SuggestionWithIcon text={type.name} icon={type.icon} callback={() => {}} />, el);
+        render(<SuggestionWithIcon text={this.getTypeTitle(type)} icon={type.icon} callback={() => {}} />, el);
     }
 
     getSuggestions(query: string): Type[] {
         let fuzzySearch = prepareFuzzySearch(query);
         let result = [];
         for (let type of this.types) {
-            if (fuzzySearch(type.name)) {
+            if (fuzzySearch(this.getTypeTitle(type)) || fuzzySearch(type.name)) {
                 result.push(type);
             }
         }


### PR DESCRIPTION
These fields can be used to describe the type itself, to better allow dealing with complex OTL schemas in the UI.