### PR TITLE
fix: Fix issues in `TFile` mocks

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -95,15 +95,24 @@ export class TFile extends TAbstractFile {
     name: string;
     basename: string;
     extension: string;
-    content: string | ArrayBuffer;
+    content: string | Buffer;
 
-    constructor(public vault: Vault, public path: string, public parent: TFolder | null, content: string | ArrayBuffer) {
+    constructor(public vault: Vault, public path: string, public parent: TFolder | null, content: string | ArrayBuffer | Buffer) {
         super();
         this.name = Path.basename(this.path);
         this.basename = Path.basename(this.path, Path.extname(this.path));
         this.extension = Path.extname(this.path);
-        this.content = content;
-        this.stat = { size: (content as ArrayBuffer).byteLength || (content as string).length };
+
+        if (content instanceof ArrayBuffer) {
+            this.content = Buffer.from(content);
+            this.stat = { size: content.byteLength };
+        } else if (content instanceof Buffer) {
+            this.content = content;
+            this.stat = { size: content.byteLength };
+        } else {
+            this.content = content;
+            this.stat = { size: content.length };
+        }
     }
 }
 
@@ -203,7 +212,7 @@ export class Vault extends Events {
     }
 
     async readBinary(file: TFile): Promise<ArrayBuffer> {
-        return (file as TFile).content as ArrayBuffer;
+        return ((file as TFile).content as Buffer).buffer;
     }
 
     getResourcePath(file: TFile): string {
@@ -226,7 +235,7 @@ export class Vault extends Events {
     }
 
     async modifyBinary(file: TFile, data: ArrayBuffer): Promise<void> {
-        (file as TFile).content = data;
+        (file as TFile).content = Buffer.from(data);
     }
 
     async append(file: TFile, data: string): Promise<void> {

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -15,11 +15,11 @@ Array.prototype.contains = function (target) {
 };
 
 export class Scope {
-    register() {}
+    register() { }
 }
 
 export class Component {
-    registerEvent() {}
+    registerEvent() { }
 }
 
 export class Events extends EventEmitter {
@@ -47,7 +47,7 @@ export class MetadataCache extends Events {
 }
 
 export class FileManager {
-    constructor(public vault: Vault) {}
+    constructor(public vault: Vault) { }
     renameFile(tfile: TFile, path: string) {
         this.vault.rename(tfile, path);
     }
@@ -66,22 +66,22 @@ export class App {
     }
 }
 
-export class MarkdownView {}
-export class Platform {}
-export class Modal {}
-export class FuzzySuggestModal {}
-export class SuggestModal {}
-export class Setting {}
-export class PluginSettingTab {}
-export class MarkdownRenderChild {}
+export class MarkdownView { }
+export class Platform { }
+export class Modal { }
+export class FuzzySuggestModal { }
+export class SuggestModal { }
+export class Setting { }
+export class PluginSettingTab { }
+export class MarkdownRenderChild { }
 export class Plugin {
-    constructor(public app: App) {}
+    constructor(public app: App) { }
     loadData() {
         return {};
     }
-    registerEvent() {}
+    registerEvent() { }
 }
-export abstract class TextFileView {}
+export abstract class TextFileView { }
 
 export abstract class TAbstractFile {
     abstract vault: Vault;


### PR DESCRIPTION
The existing code was mixing up `ArrayBuffer` and `Buffer`, which can lead to runtime errors in some cases.