### PR TITLE
fix: Add proper handling of multi-engine module loading to `jest.config.js`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,6 @@ module.exports = {
     preset: "ts-jest",
     testEnvironment: "jsdom",
     moduleDirectories: ["node_modules", "src", "<rootDir>"],
-    haste: {
-        defaultPlatform: "node",
-    },
     transform: {
         "^.+\\.tsx?$": [
             "ts-jest",

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
         ],
     },
     testEnvironmentOptions: {
-        customExportConditions: [""],
+        customExportConditions: ["node", ""],
     },
     moduleNameMapper: {
         "^react$": "preact/compat",


### PR DESCRIPTION
The issue was discovered when trying to load the `yaml` package, whose `default` export points to the `browser` instead of the `node` version.