### PR TITLE
fix: Remove deprecated `title`, `description` & `category`  properties from OTL syntax of `Type`

### DIFF
--- a/src/language/visitors/toplevel/type.ts
+++ b/src/language/visitors/toplevel/type.ts
@@ -107,10 +107,6 @@ export const Type = createVisitor({
                 return this.runChildren();
             },
             children: {
-                title: Visitors.Attribute("title", Visitors.String),
-                description: Visitors.Attribute("description", Visitors.String),
-                category: Visitors.Attribute("category", Visitors.String),
-
                 folder: Visitors.Attribute("folder", Visitors.String), // will be FolderCompletionString or String(completion=...)
                 // TODO: can be specified only in abstract types
                 // TODO: can be specified one of folder and glob


### PR DESCRIPTION
These properties were from moved from the Type's root scope into the `display` section.

This fixes an oversight from PR #36.